### PR TITLE
Team_F_changed_EX1c.lean_Ray.lean_and_Similiarity.lean

### DIFF
--- a/EuclideanGeometry/Example/ShanZun/Ex1c.lean
+++ b/EuclideanGeometry/Example/ShanZun/Ex1c.lean
@@ -9,9 +9,10 @@ namespace EuclidGeom
 variable {P : Type _} [EuclideanPlane P]
 
 namespace Shan_Problem_1_7
-/- In $\triangle ABC$, $\angle ACB = \pi /2$. Let $D$ be the midpoint of $AB$. 
+/- In $\triangle ABC$, $\angle ACB = \pi /2$. Let $D$ be the midpoint of $AB$.
 
 Prove that $CD = AB / 2$. -/
+
 variable {A B C: P} {hnd : ¬ colinear A B C}
 -- Claim: $A \ne B$ and $A \ne C$ and $B \ne C$.
 -- This is because vertices of nondegenerate triangles are distinct.
@@ -19,15 +20,15 @@ lemma b_ne_a : B ≠ A := (ne_of_not_colinear hnd).2.2
 lemma c_ne_a : C ≠ A := (ne_of_not_colinear hnd).2.1.symm
 lemma b_ne_c : B ≠ C := (ne_of_not_colinear hnd).1.symm
 --∠ A C B = π/2
-variable {hrt : (ANG A C B c_ne_a.symm b_ne_c).IsRightAngle} 
--- D is the midpoint of segment AB 
+variable {hrt : (ANG A C B c_ne_a.symm b_ne_c).IsRightAngle}
+-- D is the midpoint of segment AB
 variable {D : P} {hd : D = (SEG A B).midpoint}
 lemma d_ne_a: D ≠ A := by
   rw[hd]
   apply (Seg_nd.midpt_lies_int (SEG_nd A B (b_ne_a).symm)).2.1
   use C
   by_contra h
-  have : colinear A B C :=by 
+  have : colinear A B C :=by
     apply flip_colinear_fst_snd h
   trivial
 --Introduce the midpoint E of AC
@@ -53,20 +54,24 @@ lemma aec_colinear : colinear A E C := by
   use 2
   simp only [he,Seg.midpoint,one_div, seg_toVec_eq_vec, vec_of_pt_vadd_pt_eq_vec,smul_smul]
   norm_num
+
 lemma midpt_half_length : (SEG A D).length = (SEG A B).length/2:=by
   rw[length_eq_length_add_length (SEG A B) D,← dist_target_eq_dist_source_of_eq_midpt,half_add_self]
   simp only [Seg.source]
   exact hd
   rw[hd]
   exact Seg.midpt_lies_on (SEG A B)
+
 lemma ad_ratio : (SEG A D).length / (SEG A B).length = 2⁻¹ :=by
   apply div_eq_of_eq_mul
   apply (length_ne_zero_iff_nd.mpr (b_ne_a)).symm
   use C
   exact hnd
-  rw[mul_comm,← (div_eq_mul_inv ((SEG A B).length) 2)]
-  apply midpt_half_length
+  rw[length_eq_length_add_length (SEG A B) D,← dist_target_eq_dist_source_of_eq_midpt]
+  simp only [Seg.source,←mul_two,mul_comm,←mul_assoc,ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, mul_inv_cancel, one_mul]
   exact hd
+  rw[hd]
+  apply Seg.midpt_lies_on (SEG A B)
 lemma ae_ratio : (SEG A E).length / (SEG A C).length = 2⁻¹ :=by
   apply div_eq_of_eq_mul
   apply (length_ne_zero_iff_nd.mpr (c_ne_a)).symm
@@ -98,9 +103,9 @@ lemma hnd': ¬ colinear A D E := by
 lemma hnd'' : ¬ colinear C D E := by
   intro h
   have : colinear C D A := by
-    apply flip_colinear_snd_trd 
+    apply flip_colinear_snd_trd
     apply colinear_of_colinear_colinear_ne
-    apply (flip_colinear_snd_trd (flip_colinear_fst_snd (flip_colinear_snd_trd aec_colinear))) 
+    apply (flip_colinear_snd_trd (flip_colinear_fst_snd (flip_colinear_snd_trd aec_colinear)))
     use E
     exact he
     apply flip_colinear_snd_trd h
@@ -111,7 +116,7 @@ lemma hnd'' : ¬ colinear C D E := by
     apply colinear_of_colinear_colinear_ne
     apply adb_colinear
     apply hd
-    apply (flip_colinear_snd_trd (flip_colinear_fst_snd (flip_colinear_snd_trd this))) 
+    apply (flip_colinear_snd_trd (flip_colinear_fst_snd (flip_colinear_snd_trd this)))
     apply d_ne_a
     apply hnd
     exact hd
@@ -134,7 +139,7 @@ lemma ade_sim_abc: TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)∼ TRI_nd A B C 
   use B
   exact hnd
   exact he
---rays equal respectively
+--rays equal, respectively
   apply Angle.ext
   have h₀:(TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).angle₁.1=(SEG_nd A D (@d_ne_a P _ A B C hnd D hd)).toRay := rfl
   rw[h₀]
@@ -163,13 +168,10 @@ lemma ade_sim_abc: TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)∼ TRI_nd A B C 
   simp only [Seg.toVec,he]
   apply Seg.vec_source_midpt
 
---need to define right angle
-lemma ade_acongr_cde : (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1 IsACongrTo (TRI_nd C D E (@hnd'' P _ A B C hnd D hd E he)).1:= by
-  apply acongr_of_SAS
-  simp only [Triangle.edge₂ , Triangle.point₃]
-  sorry
-  sorry
-  sorry
+lemma ade_acongr_cde : (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1 IsACongrTo (TRI_nd C D E (@hnd'' P _ A B C hnd D hd E he)).1 := sorry
+  --need to define the value of right angle
+  --by_SAS (acongr)
+
 lemma cd : (TRI C D E).edge₃.length = (SEG C D).length:=by
   simp only [Triangle.edge₃]
 lemma ad : (TRI A D E).edge₃.length = (SEG A D).length:=by
@@ -189,7 +191,7 @@ lemma ad_eq_cd: (SEG A D).length = (SEG C D).length  := by
     unfold Seg.source Triangle.edge₃
     simp only
     exact he
-    
+
 theorem Shan_Problem_1_7 : (SEG C D).length = (SEG A B).length/2 := by
   rw[←ad_eq_cd]
   apply midpt_half_length
@@ -202,10 +204,19 @@ theorem Shan_Problem_1_7 : (SEG C D).length = (SEG A B).length/2 := by
 end Shan_Problem_1_7
 
 namespace Shan_Problem_1_8
-/- In $\triangle ABC$, let $BD$ and $CE$ be the heights, with foots $D$ and $E$, respectively. Let $F$ and $G$ be the midpoint of $BC$ and $DE$, respectively. 
+/- In $\triangle ABC$, let $BD$ and $CE$ be the heights, with foots $D$ and $E$, respectively. Let $F$ and $G$ be the midpoint of $BC$ and $DE$, respectively.
 
 Prove that $FG \perp DE$. -/
-
-
-
+variable {A B C : P} {hnd : ¬ colinear A B C}
+lemma b_ne_a : B ≠ A := (ne_of_not_colinear hnd).2.2
+lemma c_ne_a : C ≠ A := (ne_of_not_colinear hnd).2.1.symm
+lemma b_ne_c : B ≠ C := (ne_of_not_colinear hnd).1.symm
+--introduce the perps
+variable {D : P} {hd : D = perp_foot B (SEG_nd A C c_ne_a).toLine}
+variable {E : P} {he : E = perp_foot C (SEG_nd A B b_ne_a).toLine}
+variable {F G: P} {hf : F = (SEG B C).midpoint} {hg : G = (SEG D E).midpoint}
+lemma e_ne_d: E ≠ D := sorry
+lemma g_ne_f: G ≠ F := sorry
+--Failed to use the notation ⟂
+theorem Shan_Problem_1_8:(SEG_nd F G g_ne_f).toLine.toProj = (SEG_nd D E e_ne_d).toLine.toProj.perp := sorry
 end Shan_Problem_1_8

--- a/EuclideanGeometry/Example/ShanZun/Ex1c.lean
+++ b/EuclideanGeometry/Example/ShanZun/Ex1c.lean
@@ -12,17 +12,16 @@ namespace Shan_Problem_1_7
 /- In $\triangle ABC$, $\angle ACB = \pi /2$. Let $D$ be the midpoint of $AB$. 
 
 Prove that $CD = AB / 2$. -/
-variable {A B C : P} {hnd : ¬ colinear A B C}
+variable {A B C: P} {hnd : ¬ colinear A B C}
 -- Claim: $A \ne B$ and $A \ne C$ and $B \ne C$.
 -- This is because vertices of nondegenerate triangles are distinct.
 lemma b_ne_a : B ≠ A := (ne_of_not_colinear hnd).2.2
 lemma c_ne_a : C ≠ A := (ne_of_not_colinear hnd).2.1.symm
 lemma b_ne_c : B ≠ C := (ne_of_not_colinear hnd).1.symm
 --∠ A C B = π/2
-variable {hot : ∠ A C B c_ne_a.symm b_ne_c = π/2 }
+variable {hrt : (ANG A C B c_ne_a.symm b_ne_c).IsRightAngle} 
 -- D is the midpoint of segment AB 
 variable {D : P} {hd : D = (SEG A B).midpoint}
---Introduce the midpoint E of AC
 lemma d_ne_a: D ≠ A := by
   rw[hd]
   apply (Seg_nd.midpt_lies_int (SEG_nd A B (b_ne_a).symm)).2.1
@@ -31,40 +30,170 @@ lemma d_ne_a: D ≠ A := by
   have : colinear A B C :=by 
     apply flip_colinear_fst_snd h
   trivial
+--Introduce the midpoint E of AC
 variable {E : P} {he : E=  (SEG A C).midpoint}
-lemma hnd₁: ¬ colinear A D E := by
+lemma e_ne_a: E ≠ A := by
+  rw[he]
+  apply (Seg_nd.midpt_lies_int (SEG_nd A C c_ne_a)).2.1
+  use B
+  exact hnd
+lemma e_ne_c: E ≠ C := by
+  rw[he]
+  apply (Seg_nd.midpt_lies_int (SEG_nd A C c_ne_a)).2.2
+  use B
+  exact hnd
+--midpoint lies on the segment
+lemma adb_colinear : colinear A D B := by
+  apply colinear_of_vec_eq_smul_vec'
+  use 2
+  simp only [hd,Seg.midpoint,one_div, seg_toVec_eq_vec, vec_of_pt_vadd_pt_eq_vec,smul_smul]
+  norm_num
+lemma aec_colinear : colinear A E C := by
+  apply colinear_of_vec_eq_smul_vec'
+  use 2
+  simp only [he,Seg.midpoint,one_div, seg_toVec_eq_vec, vec_of_pt_vadd_pt_eq_vec,smul_smul]
+  norm_num
+lemma midpt_half_length : (SEG A D).length = (SEG A B).length/2:=by
+  rw[length_eq_length_add_length (SEG A B) D,← dist_target_eq_dist_source_of_eq_midpt,half_add_self]
+  simp only [Seg.source]
+  exact hd
+  rw[hd]
+  exact Seg.midpt_lies_on (SEG A B)
+lemma ad_ratio : (SEG A D).length / (SEG A B).length = 2⁻¹ :=by
+  apply div_eq_of_eq_mul
+  apply (length_ne_zero_iff_nd.mpr (b_ne_a)).symm
+  use C
+  exact hnd
+  rw[mul_comm,← (div_eq_mul_inv ((SEG A B).length) 2)]
+  apply midpt_half_length
+  exact hd
+lemma ae_ratio : (SEG A E).length / (SEG A C).length = 2⁻¹ :=by
+  apply div_eq_of_eq_mul
+  apply (length_ne_zero_iff_nd.mpr (c_ne_a)).symm
+  use B
+  exact hnd
+  rw[length_eq_length_add_length (SEG A C) E,← dist_target_eq_dist_source_of_eq_midpt]
+  simp only [Seg.source,←mul_two,mul_comm,←mul_assoc,ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, mul_inv_cancel, one_mul]
+  exact he
+  rw[he]
+  apply Seg.midpt_lies_on (SEG A C)
+
+lemma hnd': ¬ colinear A D E := by
   intro h'
-  have : colinear A D B := by
-    apply colinear_of_vec_eq_smul_vec'
-    use 2
-    simp only [hd,Seg.midpoint,one_div, seg_toVec_eq_vec, Complex.real_smul, Complex.ofReal_inv,Complex.ofReal_ofNat, vec_of_pt_vadd_pt_eq_vec, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,mul_inv_cancel_left₀]
   have : colinear A B E := by
-    apply colinear_of_colinear_colinear_ne this h' d_ne_a
+    apply colinear_of_colinear_colinear_ne adb_colinear h' d_ne_a
+    exact hd
     use B
     use C
     exact hnd
     exact hd
-lemma hnd₂: ¬ colinear C D E := sorry
--- lemma ade_sim_abc: (TRI_nd A D E) ∼ (TRI_nd A B C) :=sorry
-lemma ade_cong_cde : TRI A D E ≅ TRI C D E := sorry
+  have neghnd : colinear A B C := by
+    apply colinear_of_colinear_colinear_ne (flip_colinear_snd_trd this) aec_colinear e_ne_a
+    exact he
+    use B
+    use C
+    exact hnd
+    exact he
+  apply hnd neghnd
+lemma hnd'' : ¬ colinear C D E := by
+  intro h
+  have : colinear C D A := by
+    apply flip_colinear_snd_trd 
+    apply colinear_of_colinear_colinear_ne
+    apply (flip_colinear_snd_trd (flip_colinear_fst_snd (flip_colinear_snd_trd aec_colinear))) 
+    use E
+    exact he
+    apply flip_colinear_snd_trd h
+    apply e_ne_c
+    apply hnd
+    exact he
+  have : colinear A B C := by
+    apply colinear_of_colinear_colinear_ne
+    apply adb_colinear
+    apply hd
+    apply (flip_colinear_snd_trd (flip_colinear_fst_snd (flip_colinear_snd_trd this))) 
+    apply d_ne_a
+    apply hnd
+    exact hd
+  apply hnd this
+lemma ade_sim_abc: TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)∼ TRI_nd A B C hnd :=by
+  apply sim_of_SAS
+  simp only [Triangle.edge₂,Triangle.edge₃]
+  have tr13: (TRI_nd A D E(@hnd' P _ A B C hnd D hd E he)).1.point₃=E:= rfl
+  have tr23: (TRI_nd A B C hnd).1.point₃ =C:= rfl
+  have tr11: (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1.point₁=A:= rfl
+  have tr21: (TRI_nd A B C hnd).1.point₁ =A:= rfl
+  have tr12: (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1.point₂=D:= rfl
+  have tr22: (TRI_nd A B C hnd).1.point₂ =B := rfl
+  rw[tr13,tr12,tr11,tr23,tr22,tr21,length_eq_length_of_rev,length_eq_length_of_rev (SEG C A)]
+  simp only [Seg.reverse]
+  rw[ae_ratio,ad_ratio]
+  use C
+  exact hnd
+  exact hd
+  use B
+  exact hnd
+  exact he
+--rays equal respectively
+  apply Angle.ext
+  have h₀:(TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).angle₁.1=(SEG_nd A D (@d_ne_a P _ A B C hnd D hd)).toRay := rfl
+  rw[h₀]
+  have h₁:(TRI_nd A B C hnd).angle₁.1=(SEG_nd A B (@b_ne_a P _ A B C hnd)).toRay:=rfl
+  rw[h₁]
+  apply @Ray.source_int_toRay_eq_ray P _ (SEG_nd A B (@b_ne_a P _ A B C hnd)).toRay
+  apply Seg_nd.lies_int_toRay_of_lies_int
+  apply (Seg.lies_int_iff D).mpr
+  constructor
+  exact (@b_ne_a P _ A B C hnd)
+  use 1/2
+  norm_num
+  simp only [Seg.toVec,hd]
+  apply Seg.vec_source_midpt
+  have h₂:(TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).angle₁.2=(SEG_nd A E (@e_ne_a P _ A B C hnd E he)).toRay := rfl
+  rw[h₂]
+  have h₃:(TRI_nd A B C hnd).angle₁.2=(SEG_nd A C (@c_ne_a P _ A B C hnd)).toRay:=rfl
+  rw[h₃]
+  apply @Ray.source_int_toRay_eq_ray P _ (SEG_nd A C (@c_ne_a P _ A B C hnd)).toRay
+  apply Seg_nd.lies_int_toRay_of_lies_int
+  apply (Seg.lies_int_iff E).mpr
+  constructor
+  exact (@c_ne_a P _ A B C hnd)
+  use 1/2
+  norm_num
+  simp only [Seg.toVec,he]
+  apply Seg.vec_source_midpt
+
+--need to define right angle
+lemma ade_congr_cde : (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1 IsCongrTo (TRI_nd C D E (@hnd'' P _ A B C hnd D hd E he)).1:= sorry
 lemma cd : (TRI C D E).edge₃.length = (SEG C D).length:=by
   simp only [Triangle.edge₃]
 lemma ad : (TRI A D E).edge₃.length = (SEG A D).length:=by
   simp only [Triangle.edge₃]
-lemma cd_eq_ad: (SEG C D).length = (SEG A D).length := by
+lemma ad_eq_cd: (SEG A D).length = (SEG C D).length  := by
     rw[← cd,←ad]
-    apply ade_cong_cde.edge₃ 
+    apply ade_congr_cde.edge₃
     trivial
-    trivial
+    use E
+    use B
+    unfold Seg.source Triangle.edge₃
+    simp only
+    exact hnd
+    unfold Seg.target Seg.source Triangle.edge₃
+    simp only
+    exact hd
+    unfold Seg.source Triangle.edge₃
+    simp only
+    exact he
+    
 theorem Shan_Problem_1_7 : (SEG C D).length = (SEG A B).length/2 := by
-  rw[length_eq_length_add_length (SEG A B) D,← dist_target_eq_dist_source_of_eq_midpt,half_add_self]
-  simp only [Seg.source]
-  rw [cd_eq_ad]
-  trivial
-  trivial
-  rw[hd]
-  apply Seg.midpt_lies_on
-
+  rw[←ad_eq_cd]
+  apply midpt_half_length
+  exact hd
+  use B
+  apply hnd
+  apply hd
+  use E
+  exact he
 end Shan_Problem_1_7
 
 namespace Shan_Problem_1_8

--- a/EuclideanGeometry/Example/ShanZun/Ex1c.lean
+++ b/EuclideanGeometry/Example/ShanZun/Ex1c.lean
@@ -12,8 +12,58 @@ namespace Shan_Problem_1_7
 /- In $\triangle ABC$, $\angle ACB = \pi /2$. Let $D$ be the midpoint of $AB$. 
 
 Prove that $CD = AB / 2$. -/
-
-
+variable {A B C : P} {hnd : ¬ colinear A B C}
+-- Claim: $A \ne B$ and $A \ne C$ and $B \ne C$.
+-- This is because vertices of nondegenerate triangles are distinct.
+lemma b_ne_a : B ≠ A := (ne_of_not_colinear hnd).2.2
+lemma c_ne_a : C ≠ A := (ne_of_not_colinear hnd).2.1.symm
+lemma b_ne_c : B ≠ C := (ne_of_not_colinear hnd).1.symm
+--∠ A C B = π/2
+variable {hot : ∠ A C B c_ne_a.symm b_ne_c = π/2 }
+-- D is the midpoint of segment AB 
+variable {D : P} {hd : D = (SEG A B).midpoint}
+--Introduce the midpoint E of AC
+lemma d_ne_a: D ≠ A := by
+  rw[hd]
+  apply (Seg_nd.midpt_lies_int (SEG_nd A B (b_ne_a).symm)).2.1
+  use C
+  by_contra h
+  have : colinear A B C :=by 
+    apply flip_colinear_fst_snd h
+  trivial
+variable {E : P} {he : E=  (SEG A C).midpoint}
+lemma hnd₁: ¬ colinear A D E := by
+  intro h'
+  have : colinear A D B := by
+    apply colinear_of_vec_eq_smul_vec'
+    use 2
+    simp only [hd,Seg.midpoint,one_div, seg_toVec_eq_vec, Complex.real_smul, Complex.ofReal_inv,Complex.ofReal_ofNat, vec_of_pt_vadd_pt_eq_vec, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,mul_inv_cancel_left₀]
+  have : colinear A B E := by
+    apply colinear_of_colinear_colinear_ne this h' d_ne_a
+    use B
+    use C
+    exact hnd
+    exact hd
+lemma hnd₂: ¬ colinear C D E := sorry
+-- lemma ade_sim_abc: (TRI_nd A D E) ∼ (TRI_nd A B C) :=sorry
+lemma ade_cong_cde : TRI A D E ≅ TRI C D E := sorry
+lemma cd : (TRI C D E).edge₃.length = (SEG C D).length:=by
+  simp only [Triangle.edge₃]
+lemma ad : (TRI A D E).edge₃.length = (SEG A D).length:=by
+  simp only [Triangle.edge₃]
+lemma cd_eq_ad: (SEG C D).length = (SEG A D).length := by
+    rw[← cd,←ad]
+    apply ade_cong_cde.edge₃ 
+    trivial
+    trivial
+theorem Shan_Problem_1_7 : (SEG C D).length = (SEG A B).length/2 := by
+  rw[length_eq_length_add_length (SEG A B) D,← dist_target_eq_dist_source_of_eq_midpt,half_add_self]
+  simp only [Seg.source]
+  rw [cd_eq_ad]
+  trivial
+  trivial
+  rw[hd]
+  apply Seg.midpt_lies_on
 
 end Shan_Problem_1_7
 

--- a/EuclideanGeometry/Example/ShanZun/Ex1c.lean
+++ b/EuclideanGeometry/Example/ShanZun/Ex1c.lean
@@ -164,14 +164,19 @@ lemma ade_sim_abc: TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)∼ TRI_nd A B C 
   apply Seg.vec_source_midpt
 
 --need to define right angle
-lemma ade_congr_cde : (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1 IsCongrTo (TRI_nd C D E (@hnd'' P _ A B C hnd D hd E he)).1:= sorry
+lemma ade_acongr_cde : (TRI_nd A D E (@hnd' P _ A B C hnd D hd E he)).1 IsACongrTo (TRI_nd C D E (@hnd'' P _ A B C hnd D hd E he)).1:= by
+  apply acongr_of_SAS
+  simp only [Triangle.edge₂ , Triangle.point₃]
+  sorry
+  sorry
+  sorry
 lemma cd : (TRI C D E).edge₃.length = (SEG C D).length:=by
   simp only [Triangle.edge₃]
 lemma ad : (TRI A D E).edge₃.length = (SEG A D).length:=by
   simp only [Triangle.edge₃]
 lemma ad_eq_cd: (SEG A D).length = (SEG C D).length  := by
     rw[← cd,←ad]
-    apply ade_congr_cde.edge₃
+    apply ade_acongr_cde.edge₃
     trivial
     use E
     use B

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
@@ -259,6 +259,9 @@ theorem Ray.toProj_eq_toProj_of_mk_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).t
 
 theorem pt_pt_seg_toRay_eq_pt_pt_ray {A B : P} (h : B ≠ A) : (Seg_nd.mk A B h).toRay = Ray.mk_pt_pt A B h := sorry
 
+-- Given ray and a point A, A lies int the ray, then the ray from ray.source to A is just the ray
+theorem Ray.source_int_toRay_eq_ray {ray : Ray P} {A : P} {ha : A LiesInt ray} : (SEG_nd ray.1 A (ha.2)).toRay = ray := sorry
+
 end coersion_compatibility
 
 @[simp]

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
@@ -260,7 +260,7 @@ theorem Ray.toProj_eq_toProj_of_mk_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).t
 theorem pt_pt_seg_toRay_eq_pt_pt_ray {A B : P} (h : B ≠ A) : (Seg_nd.mk A B h).toRay = Ray.mk_pt_pt A B h := rfl
 
 -- Given ray and a point A, A lies int the ray, then the ray from ray.source to A is just the ray
-theorem Ray.source_int_toRay_eq_ray {ray : Ray P} {A : P} {ha : A LiesInt ray} : (SEG_nd ray.1 A (ha.2)).toRay = ray := sorry
+theorem Ray.source_int_toRay_eq_ray {ray : Ray P} {A : P} {ha : A LiesInt ray} : (SEG_nd ray.source A (ha.2)).toRay = ray := sorry
 
 end coersion_compatibility
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
@@ -54,9 +54,9 @@ theorem sim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = t
 theorem asim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = - tr₂.angle₂.value) (h₃ : tr₁.angle₃.value = - tr₂.angle₃.value) : tr₁ ∼ₐ tr₂ := sorry
 
 /- SAS -/
-theorem sim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = tr₂.angle₁): tr₁ ∼ tr₂ := sorry
+theorem sim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a : tr₁.angle₁.value = tr₂.angle₁.value): tr₁ ∼ tr₂ := sorry
 
-theorem asim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = - tr₂.angle₁): tr₁ ∼ₐ tr₂ := sorry
+theorem asim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a : tr₁.angle₁.value = - tr₂.angle₁.value): tr₁ ∼ₐ tr₂ := sorry
 
 end simiarity_criterion
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
@@ -54,7 +54,9 @@ theorem sim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = t
 theorem asim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = - tr₂.angle₂.value) (h₃ : tr₁.angle₃.value = - tr₂.angle₃.value) : tr₁ ∼ₐ tr₂ := sorry
 
 /- SAS -/
-theorem sim_of_SAS (tr₁ tr₂ : Triangle_nd P) (h₁ : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (h₂ : tr₁.angle₁=tr₂.angle₁): tr₁ ∼ tr₂ := sorry
+theorem sim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = tr₂.angle₁): tr₁ ∼ tr₂ := sorry
+
+theorem asim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = - tr₂.angle₁): tr₁ ∼ tr₂ := sorry
 
 end simiarity_criterion
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
@@ -56,7 +56,7 @@ theorem asim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = 
 /- SAS -/
 theorem sim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = tr₂.angle₁): tr₁ ∼ tr₂ := sorry
 
-theorem asim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = - tr₂.angle₁): tr₁ ∼ tr₂ := sorry
+theorem asim_of_SAS (tr₁ tr₂ : Triangle_nd P) (e : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (a₁ : tr₁.angle₁ = - tr₂.angle₁): tr₁ ∼ₐ tr₂ := sorry
 
 end simiarity_criterion
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Similarity.lean
@@ -53,6 +53,9 @@ theorem sim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = t
 
 theorem asim_of_AA (tr₁ tr₂ : Triangle_nd P) (h₂ : tr₁.angle₂.value = - tr₂.angle₂.value) (h₃ : tr₁.angle₃.value = - tr₂.angle₃.value) : tr₁ ∼ₐ tr₂ := sorry
 
+/- SAS -/
+theorem sim_of_SAS (tr₁ tr₂ : Triangle_nd P) (h₁ : tr₁.1.edge₂.length / tr₂.1.edge₂.length = tr₁.1.edge₃.length / tr₂.1.edge₃.length) (h₂ : tr₁.angle₁=tr₂.angle₁): tr₁ ∼ tr₂ := sorry
+
 end simiarity_criterion
 
 end EuclidGeom


### PR DESCRIPTION
Add sim_SAS to similarity file and a theorem (with sorry) which I believe to be useful.

Proved EX1c.1.7 and formalized EXc.1.8.  Some awkward steps involved : i didn’t find how to no suitable theorems to flip (\neg colinear) or congruence,  simp only failed to make progress for tri_nd.point so some `by rfl’ lemmas and unfolding occurs. Lean also failed to understand some complex lemmas so I need to use @+theorem to input all variables which is unpleasant. The notation \perp also failed, so I have to use the original definition. Also, more theorems about right angles are needed, for example, how to eval  and differ -pi/2 and pi/2 or apply theorems to theorem (like acongr_SAS, congr_SAS ).