### PR TITLE
Update Line.lean and Basic/Angle.lean

### DIFF
--- a/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
@@ -48,56 +48,121 @@ instance : Coe AngValue ℝ where
 section real_angvalue_compatibility
 -- this section is partially intended to be not so complete, we disencouage using real to denote the angle. for more involved use of real angvalue compatibility, please use theorems in Real.AddCircle.
 
-theorem toreal_le_pi {θ : AngValue} : θ.toReal ≤ π := sorry
+theorem AngValue.toreal_le_pi {θ : AngValue} : θ.toReal ≤ π := toReal_le_pi θ
 
-theorem toreal_neg_pi_le {θ : AngValue} : -π < θ.toReal := sorry
+theorem AngValue.neg_pi_lt_toreal {θ : AngValue} : -π < θ.toReal := neg_pi_lt_toReal θ
+
+theorem AngValue.abs_toreal_le_pi {θ : AngValue} : |θ.toReal| ≤ π := abs_toReal_le_pi θ
 
 section composite
 
 @[simp]
-theorem toreal_toangvalue_eq_self {θ : AngValue}:  (θ.toReal).toAngValue = θ := by sorry
+theorem AngValue.toreal_toangvalue_eq_self {θ : AngValue} : (θ.toReal).toAngValue = θ := coe_toReal θ
 
-theorem toangvalue_toreal_eq_self_of_neg_pi_lt_le_pi {r : ℝ} (h₁ : -π < r) (h₂ : r ≤ π) : r.toAngValue.toReal = r := sorry
+theorem toangvalue_toreal_eq_self_of_neg_pi_lt_le_pi {r : ℝ} (h₁ : -π < r) (h₂ : r ≤ π) : r.toAngValue.toReal = r :=
+  toReal_coe_eq_self_iff.mpr ⟨h₁, h₂⟩
 
-theorem toangvalue_toreal_eq_self_add_two_mul_int_mul_pi (r : ℝ) : ∃ k : ℤ, r.toAngValue.toReal = r + k * (2 * π) := sorry
+theorem toAngValue_eq_iff {r s : ℝ} : r.toAngValue = s.toAngValue ↔ ∃ k : ℤ, r - s = k * (2 * π) :=
+  QuotientAddGroup.eq_iff_sub_mem.trans <| AddSubgroup.mem_zmultiples_iff.trans <|
+    exists_congr (fun k ↦ eq_comm.trans (zsmul_eq_mul (2 * π) k).congr_right)
 
-theorem toangvalue_eq_of_add_two_mul_int_mul_pi {r₁ r₂ : ℝ} (k : ℤ) (h : r₁ = r₂ + k *(2 * π)) : r₁.toAngValue = r₂.toAngValue := sorry
+theorem toangvalue_toreal_eq_self_add_two_mul_int_mul_pi (r : ℝ) : ∃ k : ℤ, r.toAngValue.toReal = r + k * (2 * π) := by
+  rcases toAngValue_eq_iff.mp r.toAngValue.toreal_toangvalue_eq_self with ⟨k, h⟩
+  exact ⟨k, eq_add_of_sub_eq' h⟩
+
+theorem toangvalue_eq_of_add_two_mul_int_mul_pi {r₁ r₂ : ℝ} (k : ℤ) (h : r₁ = r₂ + k *(2 * π)) : r₁.toAngValue = r₂.toAngValue :=
+  toAngValue_eq_iff.mpr ⟨k, sub_eq_of_eq_add' h⟩
+
+theorem AngValue.toreal_inj {α β : AngValue} (h : α.toReal = β.toReal) : α = β := toReal_inj.mp h
 
 end composite
 
+namespace AngValue
+
 section special_value
+
 --special values -pi 0 pi 2pi -2pi `To be added`
 @[simp]
-theorem AngValue.coe_zero : ((0 : Real) : AngValue) = (0 : AngValue) := rfl
+theorem coe_zero : ((0 : Real) : AngValue) = (0 : AngValue) := rfl
 
 @[simp]
-theorem AngValue.coe_two_pi : ((2 * π : Real) : AngValue) = (0 : AngValue) := Real.Angle.coe_two_pi
+theorem toreal_eq_zero_iff {θ : AngValue} : θ.toReal = 0 ↔ θ = 0 := toReal_eq_zero_iff
 
 @[simp]
-theorem AngValue.neg_coe_pi : (-π :AngValue) = (π : AngValue) := Real.Angle.neg_coe_pi
+theorem toreal_pi : (π : AngValue).toReal = π := toReal_pi
 
-theorem AngValue.eq_zero_or_eq_pi_of_eq_neg {θ : AngValue} : θ = - θ → θ = 0 ∨ θ = π := sorry
+@[simp]
+theorem toreal_eq_pi_iff {θ : AngValue} : θ.toReal = π ↔ θ = π := toReal_eq_pi_iff
+
+theorem pi_ne_zero : (π : AngValue) ≠ 0 := Real.Angle.pi_ne_zero
+
+@[simp]
+theorem toreal_pi_div_two : ((π / 2 : ℝ) : AngValue).toReal = π / 2 := toReal_pi_div_two
+
+@[simp]
+theorem toreal_eq_pi_div_two_iff {θ : AngValue} : θ.toReal = π / 2 ↔ θ = (π / 2 : ℝ) :=
+  toReal_eq_pi_div_two_iff
+
+@[simp]
+theorem toreal_neg_pi_div_two : ((-π / 2 : ℝ) : AngValue).toReal = -π / 2 := toReal_neg_pi_div_two
+
+@[simp]
+theorem toreal_eq_neg_pi_div_two_iff {θ : AngValue} : θ.toReal = -π / 2 ↔ θ = (-π / 2 : ℝ) :=
+  toReal_eq_neg_pi_div_two_iff
+
+theorem pi_div_two_ne_zero : ((π / 2 : ℝ) : AngValue) ≠ 0 := Real.Angle.pi_div_two_ne_zero
+
+theorem neg_pi_div_two_ne_zero : ((-π / 2 : ℝ) : AngValue) ≠ 0 := Real.Angle.neg_pi_div_two_ne_zero
+
+@[simp]
+theorem coe_two_pi : ((2 * π : Real) : AngValue) = (0 : AngValue) := Real.Angle.coe_two_pi
+
+@[simp]
+theorem neg_coe_pi : (-π :AngValue) = (π : AngValue) := Real.Angle.neg_coe_pi
+
+theorem eq_zero_or_eq_pi_of_eq_neg {θ : AngValue} : θ = - θ → θ = 0 ∨ θ = π := sorry
+
+theorem sub_coe_pi_eq_add_coe_pi {θ : AngValue} : θ - π = θ + π := Real.Angle.sub_coe_pi_eq_add_coe_pi θ
 
 end special_value
 
 section group_hom
 -- `the current direction of simp is turn every thing into Real, is this good?` ` Maybe all reversed is better`
 @[simp low]
-theorem AngValue.add_coe (x y: ℝ) : (x : AngValue) + (y : AngValue) = (((x + y) : ℝ) : AngValue) := rfl
+theorem add_coe (x y: ℝ) : (x : AngValue) + (y : AngValue) = (((x + y) : ℝ) : AngValue) := rfl
 
 @[simp low]
-theorem AngValue.neg_coe (x : ℝ): -(x : AngValue) = (((-x) : ℝ) : AngValue) := rfl
+theorem neg_coe (x : ℝ): -(x : AngValue) = (((-x) : ℝ) : AngValue) := rfl
 
 @[simp low]
-theorem AngValue.sub_coe (x y: ℝ) : (x : AngValue) - (y : AngValue) = (((x - y) : ℝ) : AngValue)  := rfl
+theorem sub_coe (x y: ℝ) : (x : AngValue) - (y : AngValue) = (((x - y) : ℝ) : AngValue)  := rfl
 
 @[simp low]
-theorem AngValue.nsmul_coe (n : ℕ) (x : ℝ) : n • (x : AngValue) = ((n * x: ℝ) : AngValue) := (nsmul_eq_mul _ x) ▸ Eq.refl _
+theorem nsmul_coe (n : ℕ) (x : ℝ) : n • (x : AngValue) = ((n * x: ℝ) : AngValue) := (nsmul_eq_mul _ x) ▸ Eq.refl _
 
 @[simp low]
-theorem AngValue.zsmul_coe (n : ℤ) (x : ℝ) : n • (x : AngValue) = ((n * x : ℝ ) : AngValue) := (zsmul_eq_mul x _) ▸ Eq.refl _
+theorem zsmul_coe (n : ℤ) (x : ℝ) : n • (x : AngValue) = ((n * x : ℝ) : AngValue) := (zsmul_eq_mul x _) ▸ Eq.refl _
+
+@[simp low]
+theorem two_nsmul_coe_div_two (x : ℝ) : 2 • (↑(x / 2) : AngValue) = x.toAngValue :=
+  Real.Angle.two_nsmul_coe_div_two x
+
+@[simp low]
+theorem two_nsmul_toreal_div_two {θ : AngValue} : 2 • (θ.toReal / 2).toAngValue = θ := by
+  nth_rw 2 [← θ.toreal_toangvalue_eq_self]
+  exact two_nsmul_coe_div_two θ.toReal
+
+@[simp low]
+theorem two_zsmul_coe_div_two (x : ℝ) : (2 : ℤ) • (↑(x / 2) : AngValue) = x.toAngValue :=
+  two_nsmul_coe_div_two x
+
+@[simp low]
+theorem two_zsmul_toreal_div_two {θ : AngValue} : (2 : ℤ) • (θ.toReal / 2).toAngValue = θ :=
+  θ.two_nsmul_toreal_div_two
 
 end group_hom
+
+end AngValue
 
 end real_angvalue_compatibility
 
@@ -521,5 +586,17 @@ theorem sameRay_Vec_nd_toDir (z : Vec_nd) : SameRay ℝ z.1 z.toDir.1 := by
 theorem toDir_eq_toDir_of_sameRay (z₁ z₂ : Vec_nd) : SameRay ℝ z₁.1 z₂.1 → z₁.toDir = z₂.toDir := fun h => (sameRay_iff_eq z₁.toDir z₂.toDir).1 (SameRay.symm (SameRay.trans (SameRay.symm (SameRay.trans h (sameRay_Vec_nd_toDir z₂) (by simp only [ne_eq, ne_zero_of_Vec_nd, false_or, IsEmpty.forall_iff]))) (sameRay_Vec_nd_toDir z₁) (by simp only [ne_eq, ne_zero_of_Vec_nd, false_or, IsEmpty.forall_iff])))
 
 end sameRay_theorems
+
+section half
+
+namespace AngValue
+
+def half (θ : AngValue) : AngValue := (θ.toReal / 2).toAngValue
+
+theorem smul_two_half (θ : AngValue) : 2 • θ.half = θ := θ.two_nsmul_toreal_div_two
+
+end AngValue
+
+end half
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
@@ -70,8 +70,18 @@ theorem toangvalue_toreal_eq_self_add_two_mul_int_mul_pi (r : ℝ) : ∃ k : ℤ
   rcases toAngValue_eq_iff.mp r.toAngValue.toreal_toangvalue_eq_self with ⟨k, h⟩
   exact ⟨k, eq_add_of_sub_eq' h⟩
 
-theorem toangvalue_eq_of_add_two_mul_int_mul_pi {r₁ r₂ : ℝ} (k : ℤ) (h : r₁ = r₂ + k *(2 * π)) : r₁.toAngValue = r₂.toAngValue :=
+theorem toangvalue_eq_of_add_two_mul_int_mul_pi {r₁ r₂ : ℝ} (k : ℤ) (h : r₁ = r₂ + k * (2 * π)) : r₁.toAngValue = r₂.toAngValue :=
   toAngValue_eq_iff.mpr ⟨k, sub_eq_of_eq_add' h⟩
+
+@[simp]
+theorem add_two_pi (x : ℝ) : (x + 2 * π : ℝ).toAngValue = x.toAngValue :=
+  toangvalue_eq_of_add_two_mul_int_mul_pi 1 (by rw [Int.cast_one, one_mul])
+
+@[simp]
+theorem sub_two_pi (x : ℝ) : (x - 2 * π : ℝ).toAngValue = x.toAngValue := by
+  refine' toangvalue_eq_of_add_two_mul_int_mul_pi (- 1) _
+  rw [Int.cast_neg, Int.cast_one, neg_mul, one_mul]
+  rfl
 
 theorem AngValue.toreal_inj {α β : AngValue} (h : α.toReal = β.toReal) : α = β := toReal_inj.mp h
 
@@ -83,7 +93,7 @@ section special_value
 
 --special values -pi 0 pi 2pi -2pi `To be added`
 @[simp]
-theorem coe_zero : ((0 : Real) : AngValue) = (0 : AngValue) := rfl
+theorem coe_zero : ((0 : ℝ) : AngValue) = (0 : AngValue) := rfl
 
 @[simp]
 theorem toreal_eq_zero_iff {θ : AngValue} : θ.toReal = 0 ↔ θ = 0 := toReal_eq_zero_iff
@@ -115,14 +125,48 @@ theorem pi_div_two_ne_zero : ((π / 2 : ℝ) : AngValue) ≠ 0 := Real.Angle.pi_
 theorem neg_pi_div_two_ne_zero : ((-π / 2 : ℝ) : AngValue) ≠ 0 := Real.Angle.neg_pi_div_two_ne_zero
 
 @[simp]
-theorem coe_two_pi : ((2 * π : Real) : AngValue) = (0 : AngValue) := Real.Angle.coe_two_pi
+theorem coe_two_pi : ((2 * π : ℝ) : AngValue) = (0 : AngValue) := Real.Angle.coe_two_pi
 
 @[simp]
-theorem neg_coe_pi : (-π :AngValue) = (π : AngValue) := Real.Angle.neg_coe_pi
-
-theorem eq_zero_or_eq_pi_of_eq_neg {θ : AngValue} : θ = - θ → θ = 0 ∨ θ = π := sorry
+theorem neg_coe_pi : (- π : AngValue) = (π : AngValue) := Real.Angle.neg_coe_pi
 
 theorem sub_coe_pi_eq_add_coe_pi {θ : AngValue} : θ - π = θ + π := Real.Angle.sub_coe_pi_eq_add_coe_pi θ
+
+theorem eq_or_eq_add_pi_of_two_zsmul_eq {ψ θ : AngValue} (h : (2 : ℤ) • ψ = (2 : ℤ) • θ) : ψ = θ ∨ ψ = θ + ↑π :=
+  two_zsmul_eq_iff.mp h
+
+theorem eq_or_eq_add_pi_of_two_nsmul_eq {ψ θ : AngValue} (h : (2 : ℕ) • ψ = (2 : ℕ) • θ) : ψ = θ ∨ ψ = θ + ↑π :=
+  two_nsmul_eq_iff.mp h
+
+theorem eq_zero_or_eq_pi_of_two_nsmul_eq_zero {θ : AngValue} (h : (2 : ℕ) • θ = 0) : θ = 0 ∨ θ = π :=
+  two_nsmul_eq_zero_iff.mp h
+
+theorem ne_zero_of_two_nsmul_ne_zero {θ : AngValue} (h : (2 : ℕ) • θ ≠ 0) : θ ≠ 0 :=
+  (two_nsmul_ne_zero_iff.mp h).1
+
+theorem ne_pi_of_two_nsmul_ne_zero {θ : AngValue} (h : (2 : ℕ) • θ ≠ 0) : θ ≠ π :=
+  (two_nsmul_ne_zero_iff.mp h).2
+
+theorem eq_zero_or_eq_pi_of_two_zsmul_eq_zero {θ : AngValue} (h : (2 : ℤ) • θ = 0) : θ = 0 ∨ θ = π :=
+  two_zsmul_eq_zero_iff.mp h
+
+theorem ne_zero_of_two_zsmul_ne_zero {θ : AngValue} (h : (2 : ℤ) • θ ≠ 0) : θ ≠ 0 :=
+  (two_zsmul_ne_zero_iff.mp h).1
+
+theorem ne_pi_of_two_zsmul_ne_zero {θ : AngValue} (h : (2 : ℤ) • θ ≠ 0) : θ ≠ π :=
+  (two_zsmul_ne_zero_iff.mp h).2
+
+theorem eq_zero_or_eq_pi_of_eq_neg {θ : AngValue} (h : θ = - θ) : θ = 0 ∨ θ = π := eq_neg_self_iff.mp h
+
+theorem ne_zero_of_ne_neg {θ : AngValue} (h : θ ≠ - θ) : θ ≠ 0 := (ne_neg_self_iff.mp h).1
+
+theorem ne_pi_of_ne_neg {θ : AngValue} (h : θ ≠ - θ) : θ ≠ π := (ne_neg_self_iff.mp h).2
+
+theorem two_nsmul_eq_pi {θ : AngValue} (h : (2 : ℕ) • θ = π) : θ = (π / 2 : ℝ) ∨ θ = (- π / 2 : ℝ) :=
+  two_nsmul_eq_pi_iff.mp h
+
+theorem two_zsmul_eq_pi {θ : AngValue} (h : (2 : ℤ) • θ = π) : θ = (π / 2 : ℝ) ∨ θ = (- π / 2 : ℝ) :=
+  two_zsmul_eq_pi_iff.mp h
 
 end special_value
 
@@ -177,23 +221,27 @@ def IsPos (θ : AngValue) : Prop := sbtw 0 θ π
 def IsNeg (θ : AngValue) : Prop := sbtw (π: Real.Angle) θ 0
 
 @[pp_dot]
-def IsND (θ : AngValue) : Prop := ¬ (θ = 0 ∨ θ = π)
+structure IsND (θ : AngValue) : Prop where intro ::
+  ne_zero : θ ≠ 0
+  ne_pi : θ ≠ π
 
 section trichotomy
 
-theorem not_isneg_of_ispos {θ : AngValue} : θ.IsPos → ¬ θ.IsNeg := sorry
+theorem not_isneg_of_ispos {θ : AngValue} (h : θ.IsPos) : ¬ θ.IsNeg := sorry
 
-theorem isnd_of_ispos {θ : AngValue} : θ.IsPos → θ.IsND := sorry
+theorem isnd_of_ispos {θ : AngValue} (h : θ.IsPos) : θ.IsND := sorry
 
-theorem not_ispos_of_isneg {θ : AngValue} : θ.IsNeg → ¬ θ.IsPos := sorry
+theorem not_ispos_of_isneg {θ : AngValue} (h : θ.IsNeg) : ¬ θ.IsPos := sorry
 
-theorem isnd_of_isneg {θ : AngValue} : θ.IsNeg → θ.IsND := sorry
+theorem isnd_of_isneg {θ : AngValue} (h : θ.IsNeg) : θ.IsND := sorry
 
-theorem not_ispos_of_isnd {θ : AngValue} : θ.IsND → ¬ θ.IsPos := sorry
+theorem not_ispos_of_not_isnd {θ : AngValue} (h : ¬ θ.IsND) : ¬ θ.IsPos := sorry
 
-theorem not_isneg_of_isnd {θ : AngValue} : θ.IsND → ¬ θ.IsNeg := sorry
+theorem not_isneg_of_not_isnd {θ : AngValue} (h : ¬ θ.IsND) : ¬ θ.IsNeg := sorry
 
-theorem ispos_or_isneg_or_not_isnd {θ : AngValue} : θ.IsPos ∨ θ.IsNeg ∨ ¬ θ.IsND := sorry
+theorem wqedf {θ : AngValue} (h : θ.IsND) : θ.IsPos ∨ θ.IsNeg := sorry
+
+theorem not_isnd_or_ispos_or_isneg {θ : AngValue} : ¬ θ.IsND ∨ θ.IsPos ∨ θ.IsNeg := sorry
 
 end trichotomy
 
@@ -593,7 +641,7 @@ namespace AngValue
 
 def half (θ : AngValue) : AngValue := (θ.toReal / 2).toAngValue
 
-theorem smul_two_half (θ : AngValue) : 2 • θ.half = θ := θ.two_nsmul_toreal_div_two
+theorem smul_two_half {θ : AngValue} : 2 • θ.half = θ := θ.two_nsmul_toreal_div_two
 
 end AngValue
 

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
@@ -52,6 +52,9 @@ theorem AngValue.toreal_le_pi {θ : AngValue} : θ.toReal ≤ π := toReal_le_pi
 
 theorem AngValue.neg_pi_lt_toreal {θ : AngValue} : -π < θ.toReal := neg_pi_lt_toReal θ
 
+theorem AngValue.neg_pi_lt_toreal_le_pi {θ : AngValue} : -π < θ.toReal ∧ θ.toReal ≤ π :=
+  ⟨θ.neg_pi_lt_toreal, θ.toreal_le_pi⟩
+
 theorem AngValue.abs_toreal_le_pi {θ : AngValue} : |θ.toReal| ≤ π := abs_toReal_le_pi θ
 
 section composite
@@ -59,6 +62,7 @@ section composite
 @[simp]
 theorem AngValue.toreal_toangvalue_eq_self {θ : AngValue} : (θ.toReal).toAngValue = θ := coe_toReal θ
 
+@[simp]
 theorem toangvalue_toreal_eq_self_of_neg_pi_lt_le_pi {r : ℝ} (h₁ : -π < r) (h₂ : r ≤ π) : r.toAngValue.toReal = r :=
   toReal_coe_eq_self_iff.mpr ⟨h₁, h₂⟩
 
@@ -85,6 +89,9 @@ theorem sub_two_pi (x : ℝ) : (x - 2 * π : ℝ).toAngValue = x.toAngValue := b
 
 theorem AngValue.toreal_inj {α β : AngValue} (h : α.toReal = β.toReal) : α = β := toReal_inj.mp h
 
+@[simp]
+theorem AngValue.toreal_congr {α β : AngValue} : α.toReal = β.toReal ↔ α = β := toReal_inj
+
 end composite
 
 namespace AngValue
@@ -98,11 +105,31 @@ theorem coe_zero : ((0 : ℝ) : AngValue) = (0 : AngValue) := rfl
 @[simp]
 theorem toreal_eq_zero_iff {θ : AngValue} : θ.toReal = 0 ↔ θ = 0 := toReal_eq_zero_iff
 
+theorem eq_zero_of_toreal_eq_zero {θ : AngValue} (h : θ.toReal = 0) : θ = 0 := toReal_eq_zero_iff.mp h
+
+theorem toreal_eq_zero_of_eq_zero {θ : AngValue} (h : θ = 0) : θ.toReal = 0 := toReal_eq_zero_iff.mpr h
+
+theorem ne_zero_of_toreal_ne_zero {θ : AngValue} (h : θ.toReal ≠ 0) : θ ≠ 0 :=
+  fun hs ↦ h (toreal_eq_zero_of_eq_zero hs)
+
+theorem toreal_ne_zero_of_ne_zero {θ : AngValue} (h : θ ≠ 0) : θ.toReal ≠ 0 :=
+  fun hs ↦ h (eq_zero_of_toreal_eq_zero hs)
+
 @[simp]
 theorem toreal_pi : (π : AngValue).toReal = π := toReal_pi
 
 @[simp]
 theorem toreal_eq_pi_iff {θ : AngValue} : θ.toReal = π ↔ θ = π := toReal_eq_pi_iff
+
+theorem eq_pi_of_toreal_eq_pi {θ : AngValue} (h : θ.toReal = π) : θ = π := toReal_eq_pi_iff.mp h
+
+theorem toreal_eq_pi_of_eq_pi {θ : AngValue} (h : θ = π) : θ.toReal = π := toReal_eq_pi_iff.mpr h
+
+theorem ne_pi_of_toreal_ne_pi {θ : AngValue} (h : θ.toReal ≠ π) : θ ≠ π :=
+  fun hs ↦ h (toreal_eq_pi_of_eq_pi hs)
+
+theorem toreal_ne_pi_of_ne_pi {θ : AngValue} (h : θ ≠ π) : θ.toReal ≠ π :=
+  fun hs ↦ h (eq_pi_of_toreal_eq_pi hs)
 
 theorem pi_ne_zero : (π : AngValue) ≠ 0 := Real.Angle.pi_ne_zero
 
@@ -210,6 +237,8 @@ end AngValue
 
 end real_angvalue_compatibility
 
+open Classical
+
 section pos_neg_isnd
 
 namespace AngValue
@@ -218,62 +247,172 @@ namespace AngValue
 def IsPos (θ : AngValue) : Prop := sbtw 0 θ π
 
 @[pp_dot]
-def IsNeg (θ : AngValue) : Prop := sbtw (π: Real.Angle) θ 0
+def IsNeg (θ : AngValue) : Prop := sbtw (π: AngValue) θ 0
 
 @[pp_dot]
 structure IsND (θ : AngValue) : Prop where intro ::
   ne_zero : θ ≠ 0
   ne_pi : θ ≠ π
 
+section special_value
+
+theorem zero_not_ispos : ¬ (0 : AngValue).IsPos := sbtw_irrefl_left
+
+theorem zero_not_isneg : ¬ (0 : AngValue).IsNeg := sbtw_irrefl_right
+
+theorem zero_not_isnd : ¬ (0 : AngValue).IsND := fun nd ↦ nd.1 rfl
+
+theorem not_ispos_of_eq_zero {θ : AngValue} (h : θ = 0) : ¬ θ.IsPos := by
+  rw [h]
+  exact zero_not_ispos
+
+theorem ne_zero_of_ispos {θ : AngValue} (h : θ.IsPos) : θ ≠ 0 := fun hs ↦ not_ispos_of_eq_zero hs h
+
+theorem not_isneg_of_eq_zero {θ : AngValue} (h : θ = 0) : ¬ θ.IsNeg :=  by
+  rw [h]
+  exact zero_not_isneg
+
+theorem ne_zero_of_isneg {θ : AngValue} (h : θ.IsNeg) : θ ≠ 0 := fun hs ↦ not_isneg_of_eq_zero hs h
+
+theorem not_isnd_of_eq_zero {θ : AngValue} (h : θ = 0) : ¬ θ.IsND := fun nd ↦ nd.1 h
+
+theorem pi_not_ispos : ¬ (π : AngValue).IsPos := sbtw_irrefl_right
+
+theorem pi_not_isneg : ¬ (π : AngValue).IsNeg := sbtw_irrefl_left
+
+theorem pi_not_isnd : ¬ (π : AngValue).IsND := fun nd ↦ nd.2 rfl
+
+theorem not_ispos_of_eq_pi {θ : AngValue} (h : θ = π) : ¬ θ.IsPos :=  by
+  rw [h]
+  exact pi_not_ispos
+
+theorem ne_pi_of_ispos {θ : AngValue} (h : θ.IsPos) : θ ≠ π := fun hs ↦ not_ispos_of_eq_pi hs h
+
+theorem not_isneg_of_eq_pi {θ : AngValue} (h : θ = π) : ¬ θ.IsNeg :=  by
+  rw [h]
+  exact pi_not_isneg
+
+theorem ne_pi_of_isneg {θ : AngValue} (h : θ.IsNeg) : θ ≠ π := fun hs ↦ not_isneg_of_eq_pi hs h
+
+theorem not_isnd_of_eq_pi {θ : AngValue} (h : θ = π) : ¬ θ.IsND := fun nd ↦ nd.2 h
+
+theorem isnd_iff {θ : AngValue} : θ.IsND ↔ θ ≠ 0 ∧ θ ≠ π :=
+  ⟨fun h ↦ ⟨h.1, h.2⟩, fun h ↦ ⟨h.1, h.2⟩⟩
+
+theorem not_isnd_iff {θ : AngValue} : ¬ θ.IsND ↔ (θ = 0 ∨ θ = π) :=
+  (not_iff_not.mpr θ.isnd_iff).trans or_iff_not_and_not.symm
+
+end special_value
+
 section trichotomy
 
-theorem not_isneg_of_ispos {θ : AngValue} (h : θ.IsPos) : ¬ θ.IsNeg := sorry
+theorem not_isneg_of_ispos {θ : AngValue} (h : θ.IsPos) : ¬ θ.IsNeg := sbtw_asymm h
 
-theorem isnd_of_ispos {θ : AngValue} (h : θ.IsPos) : θ.IsND := sorry
+theorem isnd_of_ispos {θ : AngValue} (h : θ.IsPos) : θ.IsND where
+  ne_zero hs := not_ispos_of_eq_zero hs h
+  ne_pi hs := not_ispos_of_eq_pi hs h
 
-theorem not_ispos_of_isneg {θ : AngValue} (h : θ.IsNeg) : ¬ θ.IsPos := sorry
+theorem not_ispos_of_isneg {θ : AngValue} (h : θ.IsNeg) : ¬ θ.IsPos := sbtw_asymm h
 
-theorem isnd_of_isneg {θ : AngValue} (h : θ.IsNeg) : θ.IsND := sorry
+theorem isnd_of_isneg {θ : AngValue} (h : θ.IsNeg) : θ.IsND where
+  ne_zero hs := not_isneg_of_eq_zero hs h
+  ne_pi hs := not_isneg_of_eq_pi hs h
 
-theorem not_ispos_of_not_isnd {θ : AngValue} (h : ¬ θ.IsND) : ¬ θ.IsPos := sorry
+theorem not_ispos_of_not_isnd {θ : AngValue} (h : ¬ θ.IsND) : ¬ θ.IsPos := fun hs ↦ h (isnd_of_ispos hs)
 
-theorem not_isneg_of_not_isnd {θ : AngValue} (h : ¬ θ.IsND) : ¬ θ.IsNeg := sorry
+theorem not_isneg_of_not_isnd {θ : AngValue} (h : ¬ θ.IsND) : ¬ θ.IsNeg := fun hs ↦ h (isnd_of_isneg hs)
 
-theorem wqedf {θ : AngValue} (h : θ.IsND) : θ.IsPos ∨ θ.IsNeg := sorry
+theorem ispos_or_isneg_of_isnd {θ : AngValue} (h : θ.IsND) : θ.IsPos ∨ θ.IsNeg := by
+  contrapose! h
+  have h := (and_congr btw_iff_not_sbtw btw_iff_not_sbtw).mpr h
+  rcases btw_antisymm (btw_cyclic_right h.1) (btw_cyclic_left h.2) with h | h
+  · exact (pi_ne_zero h.symm).elim
+  · exact not_isnd_iff.mpr (Or.comm.mp ((or_congr_left eq_comm).mp h))
 
-theorem not_isnd_or_ispos_or_isneg {θ : AngValue} : ¬ θ.IsND ∨ θ.IsPos ∨ θ.IsNeg := sorry
+theorem not_isnd_or_ispos_or_isneg {θ : AngValue} : ¬ θ.IsND ∨ θ.IsPos ∨ θ.IsNeg :=
+  if h : θ.IsND then .inr (ispos_or_isneg_of_isnd h) else .inl h
 
 end trichotomy
 
-section neg
--- `add iff to simp`
-theorem neg_isneg_of_ispos {θ : AngValue} : θ.IsPos → (-θ).IsNeg := sorry
-
-theorem neg_ispos_of_isneg {θ : AngValue} : θ.IsNeg → (-θ).IsPos := sorry
-
-theorem neg_isnd_of_isnd {θ : AngValue} : θ.IsND → (-θ).IsND := sorry
-
-theorem isneg_of_neg_ispos {θ : AngValue} : (-θ).IsPos → θ.IsNeg := sorry
-
-theorem ispos_of_neg_isneg {θ : AngValue} : (-θ).IsNeg → θ.IsPos := sorry
-
-theorem isnd_of_neg_isnd {θ : AngValue} : (-θ).IsND → θ.IsND := sorry
-
-end neg
-
-theorem not_is_nd_iff {θ : AngValue} : ¬ θ.IsND ↔ (θ = 0 ∨ θ = π) := sorry
-
 section toreal
 -- expand this section, add θ.IsPos → (0 < (θ : ℝ)), ...
-theorem ispos_iff' {θ : AngValue} : θ.IsPos ↔ (0 < (θ : ℝ) ∧ ((θ : ℝ) < π)) := sorry
+theorem zero_le_toreal_iff {θ : AngValue} : 0 ≤ (θ : ℝ) ↔ btw 0 θ π := by
+  have hp : Fact (0 < 2 * π) := { out := Real.two_pi_pos }
+  rw [← neg_coe_pi, ← θ.toreal_toangvalue_eq_self]
+  refine' Iff.trans _ btw_cyclic.symm
+  refine' (Eq.to_iff _).trans QuotientAddGroup.btw_coe_iff.symm
+  congr
+  refine' ((toIcoMod_eq_self hp.1).mpr _).symm
+  rw [neg_add_eq_of_eq_add (two_mul π)]
+  exact ⟨neg_nonpos.mpr (le_of_lt Real.pi_pos), Real.pi_pos⟩
 
-theorem isneg_iff' {θ : AngValue} : θ.IsNeg ↔ (-π < (θ : ℝ) ∧ ((θ : ℝ) < 0)) := sorry
+theorem zero_le_toreal_of_ispos {θ : AngValue} (h : θ.IsPos) : 0 ≤ (θ : ℝ) :=
+  zero_le_toreal_iff.mpr (btw_of_sbtw h)
 
-theorem not_is_nd_iff' {θ : AngValue} : ¬ θ.IsND ↔ ((θ : ℝ) = 0 ∨ (θ : ℝ) = π) := sorry
+theorem zero_lt_toreal_of_ispos {θ : AngValue} (h : θ.IsPos) : 0 < (θ : ℝ) :=
+  (toreal_ne_zero_of_ne_zero (ne_zero_of_ispos h)).symm.lt_of_le (zero_le_toreal_of_ispos h)
+
+theorem toreal_lt_pi_of_ispos {θ : AngValue} (h : θ.IsPos) : (θ : ℝ) < π :=
+  (toreal_ne_pi_of_ne_pi (ne_pi_of_ispos h)).lt_of_le toreal_le_pi
+
+theorem toreal_lt_zero_of_isneg {θ : AngValue} (h : θ.IsNeg) : (θ : ℝ) < 0 := by
+  contrapose! h
+  exact not_sbtw_of_btw (zero_le_toreal_iff.mp h)
+
+theorem toreal_le_zero_of_isneg {θ : AngValue} (h : θ.IsNeg) : (θ : ℝ) ≤ 0 :=
+  le_of_lt (toreal_lt_zero_of_isneg h)
+
+theorem ispos_of_zero_lt_toreal_of_ne_pi {θ : AngValue} (h : 0 < (θ : ℝ)) (hn : θ ≠ π) : θ.IsPos :=
+  Or.casesOn (ispos_or_isneg_of_isnd ⟨ne_zero_of_toreal_ne_zero (ne_of_gt h), hn⟩)
+    (fun h ↦ h) (fun hp ↦ (not_lt_of_ge (toreal_le_zero_of_isneg hp) h).elim)
+
+theorem isneg_of_toreal_lt_zero {θ : AngValue} (h : (θ : ℝ) < 0) : θ.IsNeg := by
+  contrapose! h
+  exact zero_le_toreal_iff.mpr (btw_iff_not_sbtw.mpr h)
+
+theorem ispos_iff {θ : AngValue} : θ.IsPos ↔ (0 < (θ : ℝ) ∧ ((θ : ℝ) < π)) := ⟨
+  fun h ↦ ⟨zero_lt_toreal_of_ispos h, toreal_lt_pi_of_ispos h⟩,
+  fun h ↦ ispos_of_zero_lt_toreal_of_ne_pi h.1 (ne_pi_of_toreal_ne_pi (ne_of_lt h.2))⟩
+
+theorem isneg_iff {θ : AngValue} : θ.IsNeg ↔ ((θ : ℝ) < 0) :=
+  ⟨fun h ↦ toreal_lt_zero_of_isneg h, fun h ↦ isneg_of_toreal_lt_zero h⟩
+
+theorem isnd_iff' {θ : AngValue} : θ.IsND ↔ ((θ : ℝ) ≠ 0 ∧ (θ : ℝ) ≠ π) := ⟨
+  fun h ↦ ⟨toreal_ne_zero_of_ne_zero h.1, toreal_ne_pi_of_ne_pi h.2⟩,
+  fun h ↦ ⟨ne_zero_of_toreal_ne_zero h.1 ,ne_pi_of_toreal_ne_pi h.2⟩⟩
+
+theorem not_isnd_iff' {θ : AngValue} : ¬ θ.IsND ↔ ((θ : ℝ) = 0 ∨ (θ : ℝ) = π) :=
+  isnd_iff'.not.trans (not_and_or.trans (or_congr not_ne_iff not_ne_iff))
 
 end toreal
 
+section neg
+-- `add iff to simp`
+theorem neg_isneg_of_ispos {θ : AngValue} (h : θ.IsPos) : (-θ).IsNeg := sorry
+
+theorem neg_ispos_of_isneg {θ : AngValue} (h : θ.IsNeg) : (-θ).IsPos := sorry
+
+theorem neg_isnd_of_isnd {θ : AngValue} (h : θ.IsND) : (-θ).IsND := sorry
+
+theorem isneg_of_neg_ispos {θ : AngValue} (h : (-θ).IsPos) : θ.IsNeg := sorry
+
+theorem ispos_of_neg_isneg {θ : AngValue} (h : (-θ).IsNeg) : θ.IsPos := sorry
+
+theorem isnd_of_neg_isnd {θ : AngValue} (h : (-θ).IsND) : θ.IsND := sorry
+
+@[simp]
+theorem neg_ispos_iff_isneg {θ : AngValue} : (-θ).IsPos ↔ θ.IsNeg := sorry
+
+@[simp]
+theorem neg_isneg_iff_ispos {θ : AngValue} : (-θ).IsNeg ↔ θ.IsPos := sorry
+
+@[simp]
+theorem neg_isnd_iff_isnd {θ : AngValue} : (-θ).IsND ↔ θ.IsND := sorry
+
+end neg
+
 end AngValue
+
 end pos_neg_isnd
 
 -- `Do we prepare is acute, is right, ... here?` `To be added`

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Class.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Class.lean
@@ -150,7 +150,7 @@ instance : DirFig DirLine where
   todir_toproj_eq_toproj := rfl
   todirline_toline_eq_toline := rfl
   reverse := DirLine.reverse
-  rev_rev := DirLine.rev_rev_eq_self
+  rev_rev _ := DirLine.rev_rev_eq_self
   todirline_rev_eq_to_rev_dirline := by simp only [id_eq, implies_true, forall_const]
 
 instance : ProjFig Line where

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Colinear.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Colinear.lean
@@ -84,6 +84,15 @@ theorem triv_colinear (A C : P) : (colinear A A C) := by
   exfalso
   exact h.2.2 rfl
 
+theorem colinear_of_trd_eq_snd (A : P) {B C : P} (h : C = B) : colinear A B C :=
+  (dite_prop_iff_or (C = B ∨ A = C ∨ B = A)).mpr (.inl ⟨.inl h, trivial⟩)
+
+theorem colinear_of_fst_eq_snd (B : P) {A C : P} (h : A = C) : colinear A B C :=
+  (dite_prop_iff_or (C = B ∨ A = C ∨ B = A)).mpr (.inl ⟨.inr (.inl h), trivial⟩)
+
+theorem colinear_of_snd_eq_fst {A B : P} (C : P) (h : B = A)  : colinear A B C :=
+  (dite_prop_iff_or (C = B ∨ A = C ∨ B = A)).mpr (.inl ⟨.inr (.inr h), trivial⟩)
+
 /-- Given three points $A$, $B$, and $C$, if $A$, $B$, $C$ are colinear (in that order), then $A$, $C$, $B$ are colinear (in that order); in other words, swapping the last two of the three points does not change the definition of colinarity. -/
 theorem flip_colinear_snd_trd {A B C : P} (c : colinear A B C) : colinear A C B := by
   by_cases (B ≠ A) ∧ (C ≠ A)

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
@@ -282,49 +282,49 @@ theorem ray_of_pt_dirline_todirline_todir_eq_dirline_todir (A : P) (l : DirLine 
 
 end dirline_toray
 
+namespace DirLine
+
+variable {l l₁ l₂ : DirLine P}
+
 section reverse
 
 @[pp_dot]
-def DirLine.reverse (l : DirLine P) : DirLine P := by
+def reverse (l : DirLine P) : DirLine P := by
   refine' Quotient.lift (⟦·.reverse⟧) (fun a b h ↦ _) l
-  exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨neg_inj.mpr h.left, Ray.lies_on_rev_or_lies_on_iff.mp h.2⟩
+  exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨neg_inj.mpr h.1, Ray.lies_on_rev_or_lies_on_iff.mp h.2⟩
 
-theorem DirLine.rev_todir_eq_neg_todir {l : DirLine P} : l.reverse.toDir = - l.toDir := by
+theorem rev_todir_eq_neg_todir : l.reverse.toDir = - l.toDir := by
   revert l
-  rintro ⟨r⟩
+  rintro ⟨_⟩
   rfl
 
-theorem DirLine.rev_rev_eq_self (l : DirLine P) : l.reverse.reverse = l := by
+theorem rev_rev_eq_self : l.reverse.reverse = l := by
   revert l
   rintro ⟨r⟩
   exact congrArg (@Quotient.mk _ same_dir_line.setoid) r.rev_rev_eq_self
 
-theorem DirLine.lies_on_rev_iff_lies_on {A : P} {l : DirLine P} : A LiesOn l.reverse ↔ A LiesOn l := by
+theorem lies_on_rev_iff_lies_on {A : P} {l : DirLine P} : A LiesOn l.reverse ↔ A LiesOn l := by
   revert l
   rintro ⟨r⟩
-  exact Ray.lies_on_rev_or_lies_on_iff.symm
+  exact (r.lies_on_rev_or_lies_on_iff).symm
 
 end reverse
 
 section line_dirline_compatibility
 
-namespace DirLine
-
-variable (l : DirLine P) {l₁ l₂ : DirLine P}
-
 theorem rev_toline_eq_toline : l.reverse.toLine = l.toLine := by
   revert l
-  rintro ⟨r⟩
+  rintro ⟨_⟩
   exact (@Quotient.eq _ same_extn_line.setoid _ _).mpr same_extn_line.ray_rev_of_same_extn_line.symm
 
 theorem eq_of_todir_eq_of_toline_eq (h : l₁.toLine = l₂.toLine) (hd : l₁.toDir = l₂.toDir) : l₁ = l₂ := by
   revert l₁ l₂
-  rintro ⟨r₁⟩ ⟨r₂⟩ h hd
+  rintro ⟨_⟩ ⟨_⟩ h hd
   exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨hd, ((@Quotient.eq _ same_extn_line.setoid _ _).mp h).2⟩
 
 theorem eq_rev_of_todir_eq_neg_of_toline_eq (h : l₁.toLine = l₂.toLine) (hd : l₁.toDir = - l₂.toDir) : l₁ = l₂.reverse := by
   revert l₁ l₂
-  rintro ⟨r₁⟩ ⟨r₂⟩ h hd
+  rintro ⟨_⟩ ⟨_⟩ h hd
   exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨hd, ((@Quotient.eq _ same_extn_line.setoid _ _).mp h).2⟩
 
 theorem eq_rev_of_todir_ne_of_toline_eq (h : l₁.toLine = l₂.toLine) (hd : l₁.toDir ≠ l₂.toDir) : l₁ = l₂.reverse :=
@@ -335,9 +335,9 @@ theorem eq_or_eq_rev_of_toline_eq (h : l₁.toLine = l₂.toLine) : l₁ = l₂ 
   if hd : l₁.toDir = l₂.toDir then .inl (eq_of_todir_eq_of_toline_eq h hd)
   else .inr (eq_rev_of_todir_ne_of_toline_eq h hd)
 
-end DirLine
-
 end line_dirline_compatibility
+
+end DirLine
 
 namespace Line
 
@@ -503,8 +503,8 @@ theorem Seg_nd.toline_eq_rev_toline {s : Seg_nd P} : s.toLine = s.reverse.toLine
   line_of_pt_pt_eq_rev s.2
 
 theorem Seg_nd.toline_eq_extn_toline {s : Seg_nd P} : s.toLine = s.extension.toLine :=
-  (Quotient.eq (r := same_extn_line.setoid)).mpr ⟨ Seg_nd.extn_toproj.symm,
-  .inl (Seg_nd.lies_on_toray_of_lies_on Seg.target_lies_on)⟩
+  (Quotient.eq (r := same_extn_line.setoid)).mpr
+    ⟨Seg_nd.extn_toproj.symm, .inl (Seg_nd.lies_on_toray_of_lies_on Seg.target_lies_on)⟩
 
 theorem ray_of_pt_pt_toline_eq_line_of_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).toLine = LIN A B h := rfl
 
@@ -520,7 +520,7 @@ theorem Seg_nd.todirline_rev_eq_rev_toline {s : Seg_nd P} : s.toDirLine.reverse 
     ((s.todir_of_rev_eq_neg_todir).trans (s.toDirLine.rev_todir_eq_neg_todir).symm)).symm
 
 theorem Seg_nd.todirline_eq_extn_todirLine {s : Seg_nd P} : s.toDirLine = s.extension.toDirLine :=
-    (Quotient.eq (r := same_dir_line.setoid)).mpr
+  (Quotient.eq (r := same_dir_line.setoid)).mpr
     ⟨s.extn_todir, .inl (s.lies_on_toray_of_lies_on s.1.target_lies_on)⟩
 
 theorem ray_of_pt_pt_todirLine_eq_dirline_of_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).toDirLine = DLIN A B h := rfl
@@ -564,10 +564,10 @@ theorem Ray.lies_on_ray_or_lies_on_ray_rev_iff : A LiesOn r ∧ A ≠ r.source �
 theorem Ray.lies_on_toline_iff_lies_int_or_lies_int_rev_or_eq_source {r : Ray P} : (A LiesOn r.toLine) ↔ (A LiesInt r) ∨ (A LiesInt r.reverse) ∨ (A = r.source) := by
   rw [lies_int_def, lies_int_def, source_of_rev_eq_source, lies_on_ray_or_lies_on_ray_rev_iff, lies_on_toline_iff_lies_on_or_lies_on_rev]
 
-theorem Seg_nd.lies_on_extn_or_rev_extn_iff_lies_on_toline_of_not_lies_on {A : P} {seg_nd : Seg_nd P} (h : ¬ A LiesInt seg_nd.1) : A LiesOn seg_nd.toLine ↔ (A LiesOn seg_nd.extension) ∨ (A LiesOn seg_nd.reverse.extension) := by sorry
-/-  constructor
+theorem Seg_nd.lies_on_extn_or_rev_extn_iff_lies_on_toline_of_not_lies_on {A : P} {seg_nd : Seg_nd P} (h : ¬ A LiesInt seg_nd.1) : A LiesOn seg_nd.toLine ↔ (A LiesOn seg_nd.extension) ∨ (A LiesOn seg_nd.reverse.extension) := by
+  constructor
   · intro hh
-    rcases Ray.lies_on_toline_iff_lies_on_or_lies_on_rev.mp hh with h₁ | h₂
+    rcases (seg_nd.toRay.lies_on_toline_iff_lies_on_or_lies_on_rev).mp hh with h₁ | h₂
     · by_cases ax : A = seg_nd.1.source
       · rw [ax]
         exact .inr Ray.source_lies_on
@@ -576,12 +576,14 @@ theorem Seg_nd.lies_on_extn_or_rev_extn_iff_lies_on_toline_of_not_lies_on {A : P
         exact .inl Ray.source_lies_on
       exact .casesOn (lies_on_seg_nd_or_extension_of_lies_on_toray h₁)
         (fun h₁ ↦ (h ⟨h₁, ax, ay⟩).elim) (fun h₁ ↦ .inl h₁)
+    rw [rev_extn_eq_toray_rev]
     exact .inr h₂
   · exact fun hh ↦ .casesOn hh
       (fun h₁ ↦ Eq.mpr (seg_nd.toline_eq_extn_toline ▸ Eq.refl (A LiesOn seg_nd.toLine))
         ((seg_nd.extension.lies_on_toline_iff_lies_on_or_lies_on_rev).mpr (.inl h₁)))
-      (fun h₂ ↦ (seg_nd.toRay.lies_on_toline_iff_lies_on_or_lies_on_rev).mpr (.inr h₂))
--/
+      (fun h₂ ↦ (seg_nd.toRay.lies_on_toline_iff_lies_on_or_lies_on_rev).mpr <| .inr <| by
+        rw [← rev_extn_eq_toray_rev]
+        exact h₂)
 
 theorem Seg_nd.lies_on_toline_of_lies_on_extn {X : P} {seg_nd : Seg_nd P} (lieson : X LiesOn seg_nd.extension) : X LiesOn seg_nd.toLine := by
   rw [Seg_nd.toline_eq_rev_toline]
@@ -778,7 +780,7 @@ section Archimedean_property
 namespace Line
 
 -- there are two distinct points on a line
-theorem exists_ne_pt_pt_lies_on_of_line (A : P) (l : Line P) : ∃ B : P, B LiesOn l ∧ B ≠ A := by
+theorem exists_ne_pt_pt_lies_on (A : P) {l : Line P} : ∃ B : P, B LiesOn l ∧ B ≠ A := by
   rcases l.nontriv with ⟨X, Y, hx, hy, ne⟩
   exact if h : A = X then ⟨Y, hy, ne.trans_eq h.symm⟩ else ⟨X, hx, ne_comm.mp h⟩
 
@@ -806,8 +808,8 @@ end Line
 namespace DirLine
 
 -- there are two distinct points on a directed line
-theorem exists_ne_pt_pt_lies_on_of_dirline (A : P) (l : DirLine P) : ∃ B : P, B LiesOn l ∧ B ≠ A :=
-  Line.exists_ne_pt_pt_lies_on_of_line A l
+theorem exists_ne_pt_pt_lies_on (A : P) {l : DirLine P} : ∃ B : P, B LiesOn l ∧ B ≠ A :=
+  l.toLine.exists_ne_pt_pt_lies_on A
 
 theorem lies_on_of_Seg_nd_toproj_eq_toproj {A B : P} {l : DirLine P} (ha : A LiesOn l) (hab : B ≠ A) (hp : (SEG_nd A B hab).toDir = l.toDir) : B LiesOn l :=
   Line.lies_on_of_Seg_nd_toproj_eq_toproj ha hab ((congrArg Dir.toProj hp).trans l.toline_toproj_eq_toproj.symm)

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
@@ -693,65 +693,19 @@ section colinear
 
 namespace Line
 
+theorem pt_pt_linear {A B C : P} (h : B ≠ A) (hc : C LiesOn (LIN A B h) ) : colinear A B C :=
+  if hcb : C = B then colinear_of_trd_eq_snd A hcb
+  else if hac : A = C then colinear_of_fst_eq_snd B hac
+  else perm_colinear_trd_fst_snd <| (dite_prop_iff_or _).mpr <| .inr ⟨by push_neg; exact ⟨hac, h, hcb⟩,
+    ((lies_on_iff_eq_toproj_of_lies_on hcb (snd_pt_lies_on_mk_pt_pt h)).mp hc).trans <|
+      congrArg toProj (line_of_pt_pt_eq_rev h)⟩
+
 theorem linear {l : Line P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) (h₃ : C LiesOn l) : colinear A B C := by
-  revert l
-  rintro ⟨ray⟩ a b c
-  cases a with
-  | inl a =>
-    cases b with
-    | inl b =>
-      cases c with
-      | inl c =>
-        exact Ray.colinear_of_lies_on a b c
-      | inr c =>
-        let ray' := Ray.mk C ray.toDir
-        have a' : A ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev a c
-        have b' : B ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev b c
-        exact Ray.colinear_of_lies_on a' b' (Ray.source_lies_on)
-    | inr b =>
-      cases c with
-      | inl c =>
-        let ray' := Ray.mk B ray.toDir
-        have a' : A ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev a b
-        have c' : C ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev c b
-        exact Ray.colinear_of_lies_on a' (Ray.source_lies_on) c'
-      | inr c =>
-        let ray' := Ray.mk A ray.reverse.toDir
-        have a' : A LiesOn ray.reverse.reverse := by
-          rw [Ray.rev_rev_eq_self]
-          exact a
-        have b' : B ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev b a'
-        have c' : C ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev c a'
-        exact Ray.colinear_of_lies_on (ray'.source_lies_on) b' c'
-  | inr a =>
-    cases b with
-    | inl b =>
-      cases c with
-      | inl c =>
-        let ray' := Ray.mk A ray.toDir
-        have b' : B ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev b a
-        have c' : C ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev c a
-        exact Ray.colinear_of_lies_on (ray'.source_lies_on) b' c'
-      | inr c =>
-        let ray' := Ray.mk B ray.reverse.toDir
-        have b' : B LiesOn ray.reverse.reverse := by
-          rw [Ray.rev_rev_eq_self]
-          exact b
-        have a' : A ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev a b'
-        have c' : C ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev c b'
-        exact Ray.colinear_of_lies_on a' (Ray.source_lies_on) c'
-    | inr b =>
-      cases c with
-      | inl c =>
-        let ray' := Ray.mk C ray.reverse.toDir
-        have c' : C LiesOn ray.reverse.reverse := by
-          rw [Ray.rev_rev_eq_self]
-          exact c
-        have a' : A ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev a c'
-        have b' : B ∈ ray'.carrier := lies_on_pt_todir_of_pt_lies_on_rev b c'
-        exact Ray.colinear_of_lies_on  a' b' (Ray.source_lies_on)
-      | inr c =>
-        exact Ray.colinear_of_lies_on a b c
+  if h : B = A then exact colinear_of_snd_eq_fst C h
+  else
+  refine' pt_pt_linear h _
+  rw [eq_line_of_pt_pt_of_ne h h₁ h₂]
+  exact h₃
 
 theorem pt_pt_maximal {A B C : P} (h : B ≠ A) (Co : colinear A B C) : C LiesOn (LIN A B h) :=
   if hcb : C = B then by
@@ -921,9 +875,9 @@ instance PartialOrder_of_AddTorsor : PartialOrder L where
   lt a b := a -ᵥ b < 0
   le_refl _ := by simp only [vsub_self, le_refl]
   le_trans a b c hab hbc := (vsub_add_vsub_cancel a b c).symm.trans_le (add_nonpos hab hbc)
-  lt_iff_le_not_le a b := by
+  lt_iff_le_not_le a b :=
     have hv : a -ᵥ b < 0 ↔ a -ᵥ b ≤ 0 ∧ ¬ 0 ≤ a -ᵥ b := Preorder.lt_iff_le_not_le (a -ᵥ b) 0
-    exact ⟨fun hab ↦ ⟨(hv.mp hab).1, (zero_le_iff_neg_le_zero a b).not.mp (hv.mp hab).2⟩,
+    ⟨fun hab ↦ ⟨(hv.mp hab).1, (zero_le_iff_neg_le_zero a b).not.mp (hv.mp hab).2⟩,
       fun ⟨hab, hba⟩ ↦ hv.mpr ⟨hab, (zero_le_iff_neg_le_zero a b).not.mpr hba⟩⟩
   le_antisymm a b hab hba :=
     eq_of_vsub_eq_zero (PartialOrder.le_antisymm (a -ᵥ b) 0 hab ((zero_le_iff_neg_le_zero a b).mpr hba))

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Perpendicular.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Perpendicular.lean
@@ -70,6 +70,8 @@ theorem line_of_self_perp_foot_eq_perp_line_of_not_lies_on {A : P} {l : Line P} 
 theorem dist_eq_zero_iff_lies_on (A : P) (l : Line P) : dist_pt_line A l = 0 ↔ A LiesOn l :=
   length_eq_zero_iff_deg.trans ((Eq.congr rfl rfl).trans (perp_foot_eq_self_iff_lies_on A l))
 
+theorem dist_pt_line_shortest (A B : P) {l : Line P} (h : B LiesOn l) : dist A B ≥ dist_pt_line A l := sorry
+
 end Perpendicular_constructions
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Perpendicular_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Perpendicular_trash.lean
@@ -5,6 +5,6 @@ namespace EuclidGeom
 
 variable {P : Type _} [EuclideanPlane P]
 
-theorem dist_pt_line_shortest (A B : P) {l : Line P} (h : B LiesOn l) : dist A B ≥ dist_pt_line A l := sorry
+
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
@@ -277,7 +277,7 @@ theorem Seg_nd.lies_on_of_lies_on {X : P} {seg_nd : Seg_nd P} : X LiesOn seg_nd 
 theorem Seg_nd.lies_int_of_lies_int {X : P} {seg_nd : Seg_nd P} : X LiesInt seg_nd ↔ X LiesInt seg_nd.1 := ⟨ fun a => a, fun a => a ⟩
 
 /-- Given a ray, a point $X$ lies on the ray if and only if the vector from the source of the ray to $X$ is a nonnegative multiple of the direction of ray. -/
-theorem Ray.lies_on_iff {X : P} {ray : Ray P} : X LiesOn ray ↔ ∃ (t : ℝ) , 0 ≤ t ∧ VEC ray.source X = t • ray.toDir.toVec := by sorry
+theorem Ray.lies_on_iff {X : P} {ray : Ray P} : X LiesOn ray ↔ ∃ (t : ℝ) , 0 ≤ t ∧ VEC ray.source X = t • ray.toDir.toVec := Iff.rfl
 
 /-- Given a ray, a point $X$ lies in the interior of the ray if and only if the vector from the source of the ray to $X$ is a positive multiple of the direction of ray. -/
 theorem Ray.lies_int_iff {X : P} {ray : Ray P} : X LiesInt ray ↔ ∃ (t : ℝ) , 0 < t ∧ VEC ray.source X = t • ray.toDir.toVec := by
@@ -296,7 +296,7 @@ theorem Ray.lies_int_iff {X : P} {ray : Ray P} : X LiesInt ray ↔ ∃ (t : ℝ)
       exact ⟨by linarith, Dir.tovec_ne_zero ray.toDir⟩
 
 /-- For a nondegenerate segment $AB$, a point $X$ lies on $AB$ if and only if there exist a real number $t$ satisfying that $0 \leq t \leq 1$ and that the vector $\overrightarrow{AX}$ is same as $t \cdot \overrightarrow{AB}$. -/
-theorem Seg_nd.lies_on_iff {X : P} {seg_nd : Seg_nd P}: X LiesOn seg_nd ↔ ∃ (t : ℝ) , 0 ≤ t ∧ t ≤ 1 ∧ VEC seg_nd.source X = t • seg_nd.toVec_nd.1 := by sorry
+theorem Seg_nd.lies_on_iff {X : P} {seg_nd : Seg_nd P}: X LiesOn seg_nd ↔ ∃ (t : ℝ) , 0 ≤ t ∧ t ≤ 1 ∧ VEC seg_nd.source X = t • seg_nd.toVec_nd.1 := Iff.rfl
 
 /-- For a nondegenerate segment $AB$, a point $X$ lies in the interior of $AB$ if and only if there exist a real number $t$ satisfying that $0 < t < 1$ and that the vector $\overrightarrow{AX}$ is same as $t \cdot \overrightarrow{AB}$. -/
 theorem Seg_nd.lies_int_iff {X : P} {seg_nd : Seg_nd P}: X LiesInt seg_nd ↔ ∃ (t : ℝ) , 0 < t ∧ t < 1 ∧ VEC seg_nd.source X = t • seg_nd.toVec_nd.1 := by
@@ -335,7 +335,7 @@ theorem Seg_nd.lies_int_iff {X : P} {seg_nd : Seg_nd P}: X LiesInt seg_nd ↔ �
         exact ⟨ by linarith, seg_nd.toVec_nd.2⟩
 
 /-- For a segment $AB$, if there exists an interior point $X$, then it is nondegenerate. -/
-theorem Seg.is_nd_of_pt_liesint {seg : Seg P} {X : P} : (X LiesInt seg) → seg.is_nd := by sorry
+theorem Seg.is_nd_of_pt_liesint {seg : Seg P} {X : P} (h : X LiesInt seg) : seg.is_nd := sorry
 
 /-- For a segment $AB$, a point $X$ lies in the interior of $AB$ if and only if $AB$ is nondegenerate, and there exist a real number $t$ satisfying that $0 < t < 1$ and that the vector $\overrightarrow{AX}$ is same as $t \cdot \overrightarrow{AB}$. -/
 theorem Seg.lies_int_iff {X : P} {seg : Seg P}: X LiesInt seg ↔ seg.is_nd ∧ (∃ (t : ℝ) , 0 < t ∧ t < 1 ∧ VEC seg.source X = t • seg.toVec) := by
@@ -826,17 +826,16 @@ theorem pt_lies_on_ray_rev_iff_vec_opposite_dir {A : P} {ray : Ray P} : A LiesOn
 /-- A point $A$ lies on the lines determined by a ray $ray$ (i.e. lies on the ray or its reverse) if and only if the vector from the source of ray to $A$ is a real multiple of the direction vector of $ray$. -/
 theorem pt_lies_on_line_from_ray_iff_vec_parallel {A : P} {ray : Ray P} : (A LiesOn ray ∨ A LiesOn ray.reverse) ↔ ∃t : ℝ, VEC ray.source A = t • ray.toDir.toVec := by
   constructor
-  · rintro ( ⟨ t, ht, ha⟩ | ⟨ t, ht, ha⟩ )
+  · rintro (⟨t, _, ha⟩ | ⟨t, _, ha⟩)
     · use t
-    · use -t
+    · use - t
       simp only [Ray.tovec_of_rev_eq_neg_tovec, smul_neg, ← neg_smul] at ha
       exact ha
   · rintro ⟨t, h⟩
     by_cases g : 0 ≤ t
-    · left
-      exact ⟨ t, ⟨ g, h⟩ ⟩
+    · exact .inl ⟨t, ⟨g, h⟩⟩
     · right
-      use -t
+      use - t
       constructor
       · linarith
       · simp only [Ray.source_of_rev_eq_source, Ray.todir_of_rev_eq_neg_todir, Dir.tovec_neg_eq_neg_tovec, smul_neg, neg_smul, Complex.real_smul, neg_neg]
@@ -1005,17 +1004,13 @@ theorem lies_on_or_rev_iff_exist_real_vec_eq_smul {A : P} {ray : Ray P} : (A Lie
       exact eq
   · intro h
     choose t ht using h
-    by_cases k : (0 ≤ t)
-    · left
-      exact ⟨t,k,ht⟩
-    right
-    let u := -t
-    simp at k
-    have l : 0 ≤ u := sorry
-    have hu : VEC ray.reverse.1 A = u • ray.reverse.2.1 := by
-      simp
+    by_cases k : 0 ≤ t
+    · exact .inl ⟨t,k,ht⟩
+    have hu : VEC ray.reverse.1 A = (- t) • ray.reverse.2.1 := by
+      simp only [Ray.source_of_rev_eq_source, Ray.todir_of_rev_eq_neg_todir,
+        Dir.tovec_neg_eq_neg_tovec, smul_neg, neg_smul, Complex.real_smul, neg_neg]
       exact ht
-    exact ⟨u,l,hu⟩
+    exact .inr ⟨- t, neg_nonneg.mpr (le_of_lt (not_le.mp k)), hu⟩
 
 /-- Given two distinct points $A$ and $B$ and a ray, if both $A$ and $B$ lies on the ray or its reversed ray, then the projective direction of the ray is the same as the projective direction of the ray $AB$. -/
 theorem ray_toproj_eq_mk_pt_pt_toproj {A B : P} {ray : Ray P} (h : B ≠ A) (ha : A LiesOn ray ∨ A LiesOn ray.reverse) (hb : B LiesOn ray ∨ B LiesOn ray.reverse) : ray.toProj = (RAY A B h).toProj := by
@@ -1032,9 +1027,11 @@ end reverse
 
 section extension
 
+namespace Seg_nd
+
 /-- Define the extension ray of a nondegenerate segment to be the ray whose origin is the target of the segment whose direction is the same as that of the segment. -/
 @[pp_dot]
-def Seg_nd.extension (seg_nd : Seg_nd P) : Ray P where
+def extension (seg_nd : Seg_nd P) : Ray P where
   source := seg_nd.target
   toDir := seg_nd.toDir
 
@@ -1045,13 +1042,17 @@ theorem extn_eq_rev_toray_rev {seg_nd : Seg_nd P} : seg_nd.extension = seg_nd.re
   · simp only [Ray.todir_of_rev_eq_neg_todir, Seg_nd.toray_todir_eq_todir, Seg_nd.todir_of_rev_eq_neg_todir, neg_neg]
     rfl
 
+/-- The extension of the reverse of a nondegenerate segment is the same as the reverse of the ray associated to the segment. -/
+theorem rev_extn_eq_toray_rev {seg_nd : Seg_nd P} : seg_nd.reverse.extension = seg_nd.toRay.reverse :=
+  seg_nd.reverse.extn_eq_rev_toray_rev
+
 /-- The direction of the extension ray of a nondegenerate segment is the same as the direction of the segment. -/
 @[simp]
-theorem Seg_nd.extn_todir {seg_nd : Seg_nd P} : seg_nd.extension.toDir = seg_nd.toDir := by rfl
+theorem extn_todir {seg_nd : Seg_nd P} : seg_nd.extension.toDir = seg_nd.toDir := rfl
 
 /-- The projective direction of the extension ray of a nondegenerate segment is the same as the projective direction of the segment. -/
 @[simp]
-theorem Seg_nd.extn_toproj {seg_nd : Seg_nd P} : seg_nd.extension.toProj = seg_nd.toProj := by rfl
+theorem extn_toproj {seg_nd : Seg_nd P} : seg_nd.extension.toProj = seg_nd.toProj := rfl
 
 /-- Given a nondegenerate segment, a point is equal to its target if and only if it lies on the segment and its extension ray. -/
 theorem eq_target_iff_lies_on_lies_on_extn {A : P} {seg_nd : Seg_nd P} : (A LiesOn seg_nd) ∧ (A LiesOn seg_nd.extension) ↔ A = seg_nd.target := by
@@ -1062,7 +1063,7 @@ theorem eq_target_iff_lies_on_lies_on_extn {A : P} {seg_nd : Seg_nd P} : (A Lies
     exact Ray.eq_source_iff_lies_on_and_lies_on_rev.mpr ⟨ (Seg_nd.lies_on_toray_of_lies_on h1), h2 ⟩
   · intro h
     rw [h]
-    exact ⟨ Seg_nd.target_lies_on, Ray.source_lies_on ⟩
+    exact ⟨Seg_nd.target_lies_on, Ray.source_lies_on⟩
 
 /-- Given a nondegenerate segment $AB$, if a point $X$ belongs to the interior of the extension ray of $AB$, then $B$ lies in the interior of $AX$. -/
 theorem target_lies_int_seg_source_pt_of_pt_lies_int_extn {X : P} {seg_nd : Seg_nd P} (liesint : X LiesInt seg_nd.extension) : seg_nd.target LiesInt SEG seg_nd.source X := by
@@ -1143,6 +1144,8 @@ theorem lies_on_seg_nd_or_extension_of_lies_on_toray {seg_nd : Seg_nd P} {A : P}
       (mul_inv_le_iff (norm_pos_iff.2 v.2)).mpr (by rw [mul_one]; exact not_lt.mp h),
       by simpa only [eq, Vec_nd.toDir, ne_eq, Vec.norm, Complex.real_smul, Complex.ofReal_inv,
       Complex.norm_eq_abs, Complex.ofReal_mul] using by ring⟩
+
+end Seg_nd
 
 end extension
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
@@ -420,11 +420,11 @@ structure IsACongr (tr_nd₁ tr_nd₂: Triangle_nd P) : Prop where intro ::
 namespace IsACongr
 
 theorem not_cclock_of_cclock (h : tr_nd₁.IsACongr tr_nd₂) (cc : tr_nd₁.is_cclock) : ¬ tr_nd₂.is_cclock := by
-  apply Triangle_nd.clock_of_neg_angle
+  apply clock_of_neg_angle
   left
   have : - tr_nd₁.angle₁.value = tr_nd₂.angle₁.value := by simp only [h.4, neg_neg]
-  simp [<-this]
-  exact AngValue.neg_isneg_of_ispos (tr_nd₁.angle_pos_of_cclock cc).1
+  simp only [← this, AngValue.neg_isneg_iff_ispos]
+  exact (tr_nd₁.angle_pos_of_cclock cc).1
 
 protected theorem symm (h : tr_nd₁.IsACongr tr_nd₂) : tr_nd₂.IsACongr tr_nd₁ where
   edge₁ := h.1.symm

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
@@ -105,7 +105,7 @@ instance instHasCongr : HasCongr (Triangle P) where
   symm := IsCongr.symm
   trans := IsCongr.trans
 
-theorem perm_congr {tr₁ tr₂ : Triangle P} (h : tr₁.IsCongr tr₂) : (perm_vertices tr₁).IsCongr (perm_vertices tr₂) := by
+theorem perm_congr (h : tr₁.IsCongr tr₂) : (perm_vertices tr₁).IsCongr (perm_vertices tr₂) := by
   constructor
   exact h.2
   exact h.3
@@ -201,7 +201,7 @@ instance instHasACongr : HasACongr (Triangle P) where
   acongr := IsACongr
   symm := IsACongr.symm
 
-theorem perm_acongr {tr₁ tr₂ : Triangle P} (h : tr₁.IsACongr tr₂) : (perm_vertices tr₁).IsACongr (perm_vertices tr₂) := by
+theorem perm_acongr (h : tr₁.IsACongr tr₂) : (perm_vertices tr₁).IsACongr (perm_vertices tr₂) := by
   constructor
   exact h.2
   exact h.3
@@ -358,7 +358,7 @@ theorem is_cclock_of_cclock (h : tr_nd₁.IsCongr tr_nd₂) (cc : tr_nd₁.is_cc
 
 theorem area (h : tr_nd₁.IsCongr tr_nd₂) : tr_nd₁.area = tr_nd₂.area := sorry
 
-theorem perm_congr {tr_nd₁ tr_nd₂ : Triangle_nd P} (h : tr_nd₁.IsCongr tr_nd₂) : (perm_vertices tr_nd₁).IsCongr (perm_vertices tr_nd₂) where
+theorem perm_congr (h : tr_nd₁.IsCongr tr_nd₂) : (perm_vertices tr_nd₁).IsCongr (perm_vertices tr_nd₂) where
   edge₁ := h.2
   edge₂ := h.3
   edge₃ := h.1
@@ -369,7 +369,7 @@ theorem perm_congr {tr_nd₁ tr_nd₂ : Triangle_nd P} (h : tr_nd₁.IsCongr tr_
 theorem congr_iff_perm_congr (tr_nd₁ tr_nd₂ : Triangle_nd P) : tr_nd₁ ≅ tr_nd₂ ↔ perm_vertices tr_nd₁ ≅ perm_vertices tr_nd₂ :=
   ⟨fun h ↦ h.perm_congr, fun h ↦ h.perm_congr.perm_congr⟩
 
-theorem third_point_same_of_two_point_same (tr_nd₁ tr_nd₂ : Triangle_nd P) (h : tr_nd₁ ≅ tr_nd₂) (p₁ : tr_nd₁.point₁ = tr_nd₂.point₁) (p₂ : tr_nd₁.point₂ = tr_nd₂.point₂) : tr_nd₁.point₃ = tr_nd₂.point₃ := by
+theorem third_point_same_of_two_point_same (h : tr_nd₁.IsCongr tr_nd₂) (p₁ : tr_nd₁.point₁ = tr_nd₂.point₁) (p₂ : tr_nd₁.point₂ = tr_nd₂.point₂) : tr_nd₁.point₃ = tr_nd₂.point₃ := by
   have ray_eq₁ : tr_nd₁.angle₁.end_ray = tr_nd₂.angle₁.end_ray := by
     apply eq_end_ray_of_eq_value_eq_start_ray
     unfold Angle.start_ray Triangle_nd.angle₁
@@ -380,66 +380,32 @@ theorem third_point_same_of_two_point_same (tr_nd₁ tr_nd₂ : Triangle_nd P) (
     unfold Angle.end_ray Triangle_nd.angle₂
     simp only [<-p₂, <-p₁] ; rfl
     exact h.5
-  have l₁ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₁.end_ray.toLine := by
-    rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-    left
-    exact Ray.snd_pt_lies_on_mk_pt_pt tr_nd₁.nontriv₂.symm
-  have l₂ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₂.start_ray.toLine := by
-    rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-    left
-    exact Ray.snd_pt_lies_on_mk_pt_pt tr_nd₁.nontriv₁
-  have l₃ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₁.end_ray.toLine := by
-    rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-    left
-    exact Ray.snd_pt_lies_on_mk_pt_pt tr_nd₂.nontriv₂.symm
-  have l₄ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₂.start_ray.toLine := by
-    rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-    left
-    exact Ray.snd_pt_lies_on_mk_pt_pt tr_nd₂.nontriv₁
+  have l₁ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₁.end_ray.toLine :=
+    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₁.nontriv₂.symm)
+  have l₂ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₂.start_ray.toLine :=
+    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₁.nontriv₁)
+  have l₃ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₁.end_ray.toLine :=
+    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₂.nontriv₂.symm)
+  have l₄ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₂.start_ray.toLine :=
+    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₂.nontriv₁)
   have np₁ : ¬ tr_nd₁.angle₁.end_ray.toLine ∥ tr_nd₁.angle₂.start_ray.toLine := by
     by_contra pl
-    have triv := eq_of_parallel_and_pt_lies_on l₁ l₂ pl
     have l₅ : tr_nd₁.point₁ LiesOn tr_nd₁.angle₁.end_ray.toLine := by
-      rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-      left ; exact Ray.source_lies_on
+      exact .inl Ray.source_lies_on
     have l₆ : tr_nd₁.point₂ LiesOn tr_nd₁.angle₁.end_ray.toLine := by
-      rw [triv]
-      rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-      left ; exact Ray.source_lies_on
-    have col := (Line.colinear_iff_exist_line_lies_on tr_nd₁.point₁ tr_nd₁.point₂ tr_nd₁.point₃).mpr ⟨tr_nd₁.angle₁.end_ray.toLine, l₅, l₆ ,l₁⟩
-    have col' := tr_nd₁.2
-    unfold Triangle.is_nd at col'
-    have : tr_nd₁.1.point₁ = tr_nd₁.point₁ := rfl
-    rw [this] at col'
-    have : tr_nd₁.1.point₂ = tr_nd₁.point₂ := rfl
-    rw [this] at col'
-    have : tr_nd₁.1.point₃ = tr_nd₁.point₃ := rfl
-    rw [this] at col'
-    exact col' col
+      rw [eq_of_parallel_and_pt_lies_on l₁ l₂ pl]
+      exact .inl Ray.source_lies_on
+    exact tr_nd₁.2 <| (Line.colinear_iff_exist_line_lies_on tr_nd₁.point₁ tr_nd₁.point₂ tr_nd₁.point₃).mpr
+      ⟨tr_nd₁.angle₁.end_ray.toLine, l₅, l₆ ,l₁⟩
   have np₂ : ¬ tr_nd₂.angle₁.end_ray.toLine ∥ tr_nd₂.angle₂.start_ray.toLine := by
     by_contra pl
-    have triv := eq_of_parallel_and_pt_lies_on l₃ l₄ pl
-    have l₅ : tr_nd₂.point₁ LiesOn tr_nd₂.angle₁.end_ray.toLine := by
-      rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-      left ; exact Ray.source_lies_on
+    have l₅ : tr_nd₂.point₁ LiesOn tr_nd₂.angle₁.end_ray.toLine := .inl Ray.source_lies_on
     have l₆ : tr_nd₂.point₂ LiesOn tr_nd₂.angle₁.end_ray.toLine := by
-      rw [triv]
-      rw [Ray.lies_on_toline_iff_lies_on_or_lies_on_rev]
-      left ; exact Ray.source_lies_on
-    have col := (Line.colinear_iff_exist_line_lies_on tr_nd₂.point₁ tr_nd₂.point₂ tr_nd₂.point₃).mpr ⟨tr_nd₂.angle₁.end_ray.toLine, l₅, l₆ ,l₃⟩
-    have col' := tr_nd₂.2
-    unfold Triangle.is_nd at col'
-    have : tr_nd₂.1.point₁ = tr_nd₂.point₁ := rfl
-    rw [this] at col'
-    have : tr_nd₂.1.point₂ = tr_nd₂.point₂ := rfl
-    rw [this] at col'
-    have : tr_nd₂.1.point₃ = tr_nd₂.point₃ := rfl
-    rw [this] at col'
-    exact col' col
-  have inx₁ : tr_nd₁.point₃ = inx_of_extn_line tr_nd₁.angle₁.end_ray tr_nd₁.angle₂.start_ray np₁ := by exact inx_of_line_eq_inx np₁ ⟨l₁, l₂⟩
-  have inx₂ : tr_nd₂.point₃ = inx_of_extn_line tr_nd₂.angle₁.end_ray tr_nd₂.angle₂.start_ray np₂ := by exact inx_of_line_eq_inx np₂ ⟨l₃, l₄⟩
-  simp only [inx₁,inx₂,ray_eq₁,ray_eq₂]
-
+      rw [eq_of_parallel_and_pt_lies_on l₃ l₄ pl]
+      exact .inl Ray.source_lies_on
+    exact tr_nd₂.2 <| (Line.colinear_iff_exist_line_lies_on tr_nd₂.point₁ tr_nd₂.point₂ tr_nd₂.point₃).mpr
+      ⟨tr_nd₂.angle₁.end_ray.toLine, l₅, l₆ ,l₃⟩
+  simp only [inx_of_line_eq_inx np₁ ⟨l₁, l₂⟩, inx_of_line_eq_inx np₂ ⟨l₃, l₄⟩, ray_eq₁, ray_eq₂]
 
 end IsCongr
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence_trash.lean
@@ -1,4 +1,4 @@
-import EuclideanGeometry.Foundation.Axiom.Triangle.Congruence'
+import EuclideanGeometry.Foundation.Axiom.Triangle.Congruence
 
 noncomputable section
 namespace EuclidGeom

--- a/EuclideanGeometry/Foundation/Construction/Polygon/Parallelogram.lean
+++ b/EuclideanGeometry/Foundation/Construction/Polygon/Parallelogram.lean
@@ -2,7 +2,7 @@ import EuclideanGeometry.Foundation.Construction.Polygon.Quadrilateral
 import EuclideanGeometry.Foundation.Construction.Polygon.Trapezoid
 import EuclideanGeometry.Foundation.Tactic.Congruence.Congruence
 import EuclideanGeometry.Foundation.Axiom.Triangle.Basic
-import EuclideanGeometry.Foundation.Axiom.Triangle.Congruence'
+import EuclideanGeometry.Foundation.Axiom.Triangle.Congruence
 import EuclideanGeometry.Foundation.Axiom.Position.Angle_trash
 import EuclideanGeometry.Foundation.Axiom.Position.Angle_ex
 import EuclideanGeometry.Foundation.Axiom.Linear.Parallel_trash


### PR DESCRIPTION
@jjdishere
Main Changes:
1. Finish the instances `NormedAddTorsor` and `LinearOrder` of `DirLine` in Line.lean
2. Fill the sorrys in Line.lean due to the change of the definition of `Seg_nd.extension` and add related lemmas in Ray.lean
3. Add some theorems about Angle and fill all sorrys up to section `toreal` of section `pos_neg_isnd` in Basic/Angle.lean