### PR TITLE
use `PtNe` typeclass in lemmas 

### DIFF
--- a/EuclideanGeometry/Example/Index.lean
+++ b/EuclideanGeometry/Example/Index.lean
@@ -4,14 +4,14 @@ import EuclideanGeometry.Example.AOPS.Chap3
 import EuclideanGeometry.Example.AOPS.Chap3a
 
 /- Aref_Wernick -/
-import EuclideanGeometry.Example.ArefWernick.Chap1
+-- import EuclideanGeometry.Example.ArefWernick.Chap1
 import EuclideanGeometry.Example.ArefWernick.Chap1a
 
 /- ShanZun -/
-import EuclideanGeometry.Example.ShanZun.Ex1
+-- import EuclideanGeometry.Example.ShanZun.Ex1
 import EuclideanGeometry.Example.ShanZun.Ex1a
 import EuclideanGeometry.Example.ShanZun.Ex1b
-import EuclideanGeometry.Example.ShanZun.Ex1c
+-- import EuclideanGeometry.Example.ShanZun.Ex1c
 import EuclideanGeometry.Example.ShanZun.Ex1d
 
 import EuclideanGeometry.Example.ExerciseXT8

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Class.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Class.lean
@@ -45,7 +45,10 @@ section carrier
 abbrev PtNe [EuclideanPlane P] (A B : P) : Prop :=
   Fact <| A ≠ B
 
-instance [EuclideanPlane P] (A B : P) [h : PtNe A B] : PtNe B A := ⟨h.out.symm⟩
+instance PtNe.symm [EuclideanPlane P] {A B : P} [h : PtNe A B] : PtNe B A := ⟨h.out.symm⟩
+
+@[simp]
+lemma pt_ne [EuclideanPlane P] {A B : P} [h : PtNe A B] : A ≠ B := @Fact.out _ h
 
 /-- The class of plane figures. We say `α` is a plane figure, if for every given Euclidean plane `P`, `α P` is a collection of specific figures on `P`, each equipped with a carrier set of type `Set P`. -/
 class Fig (α : Type*) (P : outParam <| Type*) where

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Plane.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Plane.lean
@@ -105,6 +105,6 @@ def delabVecNDMkPtPt : Delab := do
       `(VEC_nd $A $B $(← delab))
 
 @[simp]
-lemma VecND.coe_mkPtPt (A B : P) (h : B ≠ A) : VEC_nd A B h = VEC A B := rfl
+lemma VecND.coe_mkPtPt (A B : P) [_h : Fact (B ≠ A)] : VEC_nd A B = VEC A B := rfl
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Circle/Basic.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Circle/Basic.lean
@@ -129,55 +129,54 @@ section colinear
 
 namespace Circle
 
-lemma pts_lieson_circle_vec_eq {A B : P} {ω : Circle P} (hne : B ≠ A) (hl₁ : A LiesOn ω) (hl₂ : B LiesOn ω) : VEC A (perp_foot ω.center (LIN A B hne)) = VEC (perp_foot ω.center (LIN A B hne)) B := by
-  have htri₁ : (dist ω.center (perp_foot ω.center (LIN A B hne))) ^ 2 + (dist A (perp_foot ω.center (LIN A B hne))) ^ 2 = (dist ω.center A) ^ 2 := by
+lemma pts_lieson_circle_vec_eq {A B : P} {ω : Circle P} [hne : PtNe B A] (hl₁ : A LiesOn ω) (hl₂ : B LiesOn ω) : VEC A (perp_foot ω.center (LIN A B)) = VEC (perp_foot ω.center (LIN A B)) B := by
+  have htri₁ : (dist ω.center (perp_foot ω.center (LIN A B))) ^ 2 + (dist A (perp_foot ω.center (LIN A B))) ^ 2 = (dist ω.center A) ^ 2 := by
     rw [← Seg.length_eq_dist, ← Seg.length_eq_dist, ← Seg.length_eq_dist]
     apply Pythagoras_of_perp_foot
     apply Line.fst_pt_lies_on_mk_pt_pt
-  have htri₂ : (dist ω.center (perp_foot ω.center (LIN A B hne))) ^ 2 + (dist B (perp_foot ω.center (LIN A B hne))) ^ 2 = (dist ω.center B) ^ 2 := by
+  have htri₂ : (dist ω.center (perp_foot ω.center (LIN A B))) ^ 2 + (dist B (perp_foot ω.center (LIN A B))) ^ 2 = (dist ω.center B) ^ 2 := by
     rw [← Seg.length_eq_dist, ← Seg.length_eq_dist, ← Seg.length_eq_dist]
     apply Pythagoras_of_perp_foot
     apply Line.snd_pt_lies_on_mk_pt_pt
-  apply distinct_pts_same_dist_vec_eq
-  · exact hne
-  · have : (perp_foot ω.center (LIN A B hne)) LiesOn (LIN A B hne) := perp_foot_lies_on_line _ _
-    have : colinear A B (perp_foot ω.center (LIN A B hne)) := Line.pt_pt_linear _ this
-    have : colinear (perp_foot ω.center (LIN A B hne)) A B := perm_colinear_trd_fst_snd this
-    apply Line.pt_pt_maximal _ this
+  have : PtNe A (perp_foot ω.center (LIN A B))
+  · apply Fact.mk
     intro heq
     have : (dist ω.center B) ^ 2 = ω.radius ^ 2 := by rw [hl₂]
     have : (dist ω.center B) ^ 2 > ω.radius ^ 2 := by
       calc
-        _ = (dist ω.center (perp_foot ω.center (LIN A B hne))) ^ 2 + (dist B (perp_foot ω.center (LIN A B hne))) ^ 2 := by rw [htri₂]
+        _ = (dist ω.center (perp_foot ω.center (LIN A B))) ^ 2 + (dist B (perp_foot ω.center (LIN A B))) ^ 2 := by rw [htri₂]
         _ = (dist ω.center A) ^ 2 + (dist B A) ^ 2 := by rw [← heq]
         _ = ω.radius ^ 2 + (dist B A) ^ 2 := by rw [hl₁]
         _ > ω.radius ^ 2 := by
           simp
-          apply (sq_pos_iff _).mpr
-          apply dist_ne_zero.mpr hne
     linarith
+  apply distinct_pts_same_dist_vec_eq
+  · have : (perp_foot ω.center (LIN A B)) LiesOn (LIN A B) := perp_foot_lies_on_line _ _
+    have : colinear A B (perp_foot ω.center (LIN A B)) := Line.pt_pt_linear this
+    have : colinear (perp_foot ω.center (LIN A B)) A B := perm_colinear_trd_fst_snd this
+    apply Line.pt_pt_maximal this
   apply (sq_eq_sq dist_nonneg dist_nonneg).mp
   calc
-    _ = (dist B (perp_foot ω.center (LIN A B hne))) ^ 2 := by rw [dist_comm]
-    _ = (dist ω.center B) ^ 2 - (dist ω.center (perp_foot ω.center (LIN A B hne))) ^ 2 := by rw [← htri₂]; ring
-    _ = (dist ω.center A) ^ 2 - (dist ω.center (perp_foot ω.center (LIN A B hne))) ^ 2 := by rw [hl₂, hl₁]
-    _ = (dist A (perp_foot ω.center (LIN A B hne))) ^ 2 := by rw [← htri₁]; ring
-    _ = (dist (perp_foot ω.center (LIN A B hne)) A) ^ 2 := by rw [dist_comm]
+    _ = (dist B (perp_foot ω.center (LIN A B))) ^ 2 := by rw [dist_comm]
+    _ = (dist ω.center B) ^ 2 - (dist ω.center (perp_foot ω.center (LIN A B))) ^ 2 := by rw [← htri₂]; ring
+    _ = (dist ω.center A) ^ 2 - (dist ω.center (perp_foot ω.center (LIN A B))) ^ 2 := by rw [hl₂, hl₁]
+    _ = (dist A (perp_foot ω.center (LIN A B))) ^ 2 := by rw [← htri₁]; ring
+    _ = (dist (perp_foot ω.center (LIN A B)) A) ^ 2 := by rw [dist_comm]
 
 
-theorem three_pts_lieson_circle_not_colinear {A B C : P} {ω : Circle P} (hne₁ : B ≠ A) (hne₂ : C ≠ B) (hne₃ : A ≠ C) (hl₁ : A LiesOn ω) (hl₂ : B LiesOn ω) (hl₃ : C LiesOn ω) : ¬ (colinear A B C) := by
+theorem three_pts_lieson_circle_not_colinear {A B C : P} {ω : Circle P} [hne₁ : PtNe B A] [hne₂ : PtNe C B] [hne₃ : PtNe A C] (hl₁ : A LiesOn ω) (hl₂ : B LiesOn ω) (hl₃ : C LiesOn ω) : ¬ (colinear A B C) := by
   intro h
-  have eq₁ : VEC A (perp_foot ω.center (LIN A B hne₁)) = VEC (perp_foot ω.center (LIN A B hne₁)) B := pts_lieson_circle_vec_eq hne₁ hl₁ hl₂
-  have eq₂ : VEC A (perp_foot ω.center (LIN A C hne₃.symm)) = VEC (perp_foot ω.center (LIN A C hne₃.symm)) C := pts_lieson_circle_vec_eq hne₃.symm hl₁ hl₃
-  have ha : A LiesOn LIN A B hne₁ := Line.fst_pt_lies_on_mk_pt_pt hne₁
-  have hc : C LiesOn LIN A B hne₁ := Line.pt_pt_maximal hne₁ h
-  have : LIN A C hne₃.symm = LIN A B hne₁ := Line.eq_line_of_pt_pt_of_ne hne₃.symm ha hc
+  have eq₁ : VEC A (perp_foot ω.center (LIN A B)) = VEC (perp_foot ω.center (LIN A B)) B := pts_lieson_circle_vec_eq hl₁ hl₂
+  have eq₂ : VEC A (perp_foot ω.center (LIN A C)) = VEC (perp_foot ω.center (LIN A C)) C := pts_lieson_circle_vec_eq hl₁ hl₃
+  have ha : A LiesOn LIN A B := Line.fst_pt_lies_on_mk_pt_pt
+  have hc : C LiesOn LIN A B := Line.pt_pt_maximal h
+  have : LIN A C = LIN A B := Line.eq_line_of_pt_pt_of_ne ha hc
   rw [this] at eq₂
   have : VEC B C = 0 := by
     calc
-      _ = VEC (perp_foot ω.center (LIN A B hne₁)) C - VEC (perp_foot ω.center (LIN A B hne₁)) B := by rw [vec_sub_vec]
+      _ = VEC (perp_foot ω.center (LIN A B)) C - VEC (perp_foot ω.center (LIN A B)) B := by rw [vec_sub_vec]
       _ = 0 := by rw [← eq₁, ← eq₂, sub_self]
-  have : VEC B C ≠ 0 := (ne_iff_vec_ne_zero _ _).mp hne₂
+  have : VEC B C ≠ 0 := (ne_iff_vec_ne_zero _ _).mp hne₂.out
   tauto
 
 end Circle

--- a/EuclideanGeometry/Foundation/Axiom/Circle/IncribedAngle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Circle/IncribedAngle.lean
@@ -13,13 +13,15 @@ structure Arc (P : Type _) [EuclideanPlane P] where
   target : P
   circle : Circle P
   ison : (source LiesOn circle) ∧ (target LiesOn circle)
-  endpts_ne : target ≠ source
+  endpts_ne : PtNe target source
 
 variable {P : Type _} [EuclideanPlane P]
 
 namespace Arc
 
-protected def mk_pt_pt_circle (A B : P) {ω : Circle P} (h : B ≠ A) (ha : A LiesOn ω) (hb : B LiesOn ω) : Arc P where
+attribute [instance] Arc.endpts_ne
+
+protected def mk_pt_pt_circle (A B : P) {ω : Circle P} [h : PtNe B A] (ha : A LiesOn ω) (hb : B LiesOn ω) : Arc P where
   source := A
   target := B
   circle := ω
@@ -35,7 +37,7 @@ section position
 
 namespace Arc
 
-protected def IsOn (p : P) (β : Arc P) : Prop := (p LiesOn β.circle) ∧ (¬ p LiesOnLeft (DLIN β.source β.target β.endpts_ne))
+protected def IsOn (p : P) (β : Arc P) : Prop := (p LiesOn β.circle) ∧ (¬ p LiesOnLeft (DLIN β.source β.target))
 
 def Isnot_arc_endpts (p : P) (β : Arc P) : Prop := (p ≠ β.source) ∧ (p ≠ β.target)
 
@@ -68,6 +70,9 @@ theorem arc_center_isnot_arc_endpts (β : Arc P) : Isnot_arc_endpts β.circle.ce
   have : β.circle.radius > 0 := β.circle.rad_pos
   linarith
 
+instance (β : Arc P) : PtNe β.source β.circle.center := ⟨(arc_center_isnot_arc_endpts β).1.symm⟩
+instance (β : Arc P) : PtNe β.target β.circle.center := ⟨(arc_center_isnot_arc_endpts β).2.symm⟩
+
 def complement (β : Arc P) : Arc P where
   source := β.target
   target := β.source
@@ -75,25 +80,25 @@ def complement (β : Arc P) : Arc P where
   ison := and_comm.mp β.ison
   endpts_ne := β.endpts_ne.symm
 
-lemma liesint_arc_not_lieson_dlin {β : Arc P} {p : P} (h : p LiesInt β) : ¬ (p LiesOn (DLIN β.source β.target β.endpts_ne)) := by
+lemma liesint_arc_not_lieson_dlin {β : Arc P} {p : P} (h : p LiesInt β) : ¬ (p LiesOn (DLIN β.source β.target)) := by
   intro hl
-  have hl : p LiesOn (LIN β.source β.target β.endpts_ne) := hl
-  have hco : colinear β.source β.target p := Line.pt_pt_linear β.endpts_ne hl
-  have hco' : ¬ (colinear β.source β.target p) := Circle.three_pts_lieson_circle_not_colinear β.endpts_ne h.2.2 h.2.1.symm β.ison.1 β.ison.2 h.1.1
+  have hl : p LiesOn (LIN β.source β.target) := hl
+  have hco : colinear β.source β.target p := Line.pt_pt_linear hl
+  have hco' : ¬ (colinear β.source β.target p) := Circle.three_pts_lieson_circle_not_colinear (hne₂ := ⟨h.2.2⟩) (hne₃ := ⟨h.2.1.symm⟩) β.ison.1 β.ison.2 h.1.1
   tauto
 
-theorem liesint_arc_liesonright_dlin {β : Arc P} {p : P} (h : p LiesInt β) : p LiesOnRight (DLIN β.source β.target β.endpts_ne) := by
-  have hnl : ¬ (p LiesOn (DLIN β.source β.target β.endpts_ne)) := liesint_arc_not_lieson_dlin h
-  have hnll : ¬ (p LiesOnLeft (DLIN β.source β.target β.endpts_ne)) := h.1.2
-  rcases DirLine.lieson_or_liesonleft_or_liesonright p (DLIN β.source β.target β.endpts_ne) with hh | (hh | hh)
+theorem liesint_arc_liesonright_dlin {β : Arc P} {p : P} (h : p LiesInt β) : p LiesOnRight (DLIN β.source β.target) := by
+  have hnl : ¬ (p LiesOn (DLIN β.source β.target)) := liesint_arc_not_lieson_dlin h
+  have hnll : ¬ (p LiesOnLeft (DLIN β.source β.target)) := h.1.2
+  rcases DirLine.lieson_or_liesonleft_or_liesonright p (DLIN β.source β.target) with hh | (hh | hh)
   · exfalso; tauto
   · exfalso; tauto
   exact hh
 
-theorem liesint_complementary_arc_liesonleft_dlin {β : Arc P} {p : P} (h : p LiesInt β.complement) : p LiesOnLeft (DLIN β.source β.target β.endpts_ne) := by
-  have hh : p LiesOnRight (DLIN β.target β.source β.endpts_ne.symm) := by apply liesint_arc_liesonright_dlin h
+theorem liesint_complementary_arc_liesonleft_dlin {β : Arc P} {p : P} (h : p LiesInt β.complement) : p LiesOnLeft (DLIN β.source β.target) := by
+  have hh : p LiesOnRight (DLIN β.target β.source) := by apply liesint_arc_liesonright_dlin h
   apply liesonleft_iff_liesonright_reverse.mpr
-  rw [← DirLine.pt_pt_rev_eq_rev β.endpts_ne]
+  rw [← DirLine.pt_pt_rev_eq_rev]
   exact hh
 
 end Arc
@@ -113,13 +118,13 @@ protected def IsMajor (β : Arc P) : Prop := β.cangle.value.toReal < 0
 
 protected def IsMinor (β : Arc P) : Prop := β.cangle.value.toReal > 0
 
-protected def IsAntipode (A B : P) {ω : Circle P} (h : B ≠ A) (h₁ : A LiesOn ω) (h₂ : B LiesOn ω) : Prop := (ARC A B h h₁ h₂).cangle.value = π
+protected def IsAntipode (A B : P) {ω : Circle P} [_h : PtNe B A] (h₁ : A LiesOn ω) (h₂ : B LiesOn ω) : Prop := (ARC A B h₁ h₂).cangle.value = π
 
 theorem cangle_of_complementary_arc_are_opposite (β : Arc P) : β.cangle.value = - β.complement.cangle.value := by
-  show ∠ β.source β.circle.center β.target (arc_center_isnot_arc_endpts β).1.symm (arc_center_isnot_arc_endpts β).2.symm = -∠ β.target β.circle.center β.source (arc_center_isnot_arc_endpts β).2.symm (arc_center_isnot_arc_endpts β).1.symm
+  show (∠ β.source β.circle.center β.target = -∠ β.target β.circle.center β.source)
   apply neg_value_of_rev_ang
 
-theorem antipode_iff_colinear (A B : P) {ω : Circle P} (h : B ≠ A) (h₁ : A LiesOn ω) (h₂ : B LiesOn ω) : Arc.IsAntipode A B h h₁ h₂ ↔ colinear ω.center A B := by
+theorem antipode_iff_colinear (A B : P) {ω : Circle P} [h : PtNe B A] (h₁ : A LiesOn ω) (h₂ : B LiesOn ω) : Arc.IsAntipode A B h₁ h₂ ↔ colinear ω.center A B := by
   constructor
   · intro hh
     unfold Arc.IsAntipode Arc.cangle Arc.mk_pt_pt_circle Arc.angle_mk_pt_arc at hh
@@ -137,11 +142,11 @@ namespace Arc
 
 theorem inscribed_angle_is_positive {p : P} {β : Arc P} (h : p LiesInt β.complement) : (Arc.angle_mk_pt_arc p β h.2.symm).value.IsPos := by
   unfold Arc.angle_mk_pt_arc
-  apply liesonleft_angle_ispos β.endpts_ne (liesint_complementary_arc_liesonleft_dlin h)
+  apply liesonleft_angle_ispos (liesint_complementary_arc_liesonleft_dlin h)
 
 theorem inscribed_angle_of_complementary_arc_is_negative {p : P} {β : Arc P} (h : p LiesInt β) : (Arc.angle_mk_pt_arc p β h.2).value.IsNeg := by
   unfold Arc.angle_mk_pt_arc
-  apply liesonright_angle_isneg β.endpts_ne (liesint_arc_liesonright_dlin h)
+  apply liesonright_angle_isneg (liesint_arc_liesonright_dlin h)
 
 theorem cangle_eq_two_times_inscribed_angle {p : P} {β : Arc P} (h₁ : p LiesOn β.circle) (h₂ : Isnot_arc_endpts p β) : β.cangle.value = 2 • (Arc.angle_mk_pt_arc p β h₂).value := by
   have ne : p ≠ β.circle.center := Circle.pt_lieson_ne_center h₁
@@ -184,7 +189,7 @@ theorem cangle_eq_two_times_inscribed_angle {p : P} {β : Arc P} (h₁ : p LiesO
     _ = 2 • (∠ β.source p β.target h₂.1.symm h₂.2.symm) := by rw [← zero_sub, ← eq₃, add_sub_cancel']
     _ = 2 • (Arc.angle_mk_pt_arc p β h₂).value := rfl
 
-theorem inscribed_angle_of_diameter_eq_mod_pi {p : P} {β : Arc P} (h₁ : p LiesOn β.circle) (h₂ : Arc.IsAntipode β.source β.target β.endpts_ne β.ison.1 β.ison.2) (h₃ : Isnot_arc_endpts p β) : (Arc.angle_mk_pt_arc p β h₃).dvalue = ((π / 2 : ℝ) : AngDValue) := by
+theorem inscribed_angle_of_diameter_eq_mod_pi {p : P} {β : Arc P} (h₁ : p LiesOn β.circle) (h₂ : Arc.IsAntipode β.source β.target β.ison.1 β.ison.2) (h₃ : Isnot_arc_endpts p β) : (Arc.angle_mk_pt_arc p β h₃).dvalue = ((π / 2 : ℝ) : AngDValue) := by
   have : β.cangle.value = π := h₂
   have : 2 • (Arc.angle_mk_pt_arc p β h₃).value = π := by
     rw [← this, ← cangle_eq_two_times_inscribed_angle]

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Class.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Class.lean
@@ -169,8 +169,8 @@ open Line DirLine
 
 variable {P : Type _} [EuclideanPlane P]
 
-theorem carrier_toProj_eq_toProj {α} {A B : P} [ProjFig α P] {F : α} (h : B ≠ A) (ha : A LiesOn F) (hb : B LiesOn F) : (SEG_nd A B h).toProj = toProj' F :=
-  (toProj_eq_seg_nd_toProj_of_lies_on (carrier_subset_toLine ha) (carrier_subset_toLine hb) h).trans toLine_toProj_eq_toProj
+theorem carrier_toProj_eq_toProj {α} {A B : P} [ProjFig α P] {F : α} [_h : PtNe B A] (ha : A LiesOn F) (hb : B LiesOn F) : (SEG_nd A B).toProj = toProj' F :=
+  (toProj_eq_seg_nd_toProj_of_lies_on (carrier_subset_toLine ha) (carrier_subset_toLine hb)).trans toLine_toProj_eq_toProj
 
 theorem line_of_pt_toProj_eq_to_line {α} {A : P} [ProjFig α P] {F : α} (h : A LiesOn F) : Line.mk_pt_proj A (toProj F) = toLine F :=
   mk_pt_proj_eq_of_eq_toProj (carrier_subset_toLine h) toLine_toProj_eq_toProj.symm

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
@@ -52,8 +52,8 @@ theorem vec_parallel_of_same_extn_line {r r' : Ray P} (h : same_extn_line r r') 
 theorem ray_rev_of_same_extn_line {r : Ray P} : same_extn_line r r.reverse :=
   ⟨Ray.toProj_of_rev_eq_toProj.symm, .inr Ray.source_lies_on⟩
 
-theorem pt_pt_ray_same_extn_line_of_pt_pt_lies_on_line {A B : P} {r : Ray P} (h : B ≠ A) (ha : A LiesOn r ∨ A LiesOn r.reverse) (hb : B LiesOn r ∨ B LiesOn r.reverse) : same_extn_line r (Ray.mk_pt_pt A B h) :=
-  ⟨ray_toProj_eq_mk_pt_pt_toProj h ha hb, ha⟩
+theorem pt_pt_ray_same_extn_line_of_pt_pt_lies_on_line {A B : P} {r : Ray P} [_h : PtNe B A] (ha : A LiesOn r ∨ A LiesOn r.reverse) (hb : B LiesOn r ∨ B LiesOn r.reverse) : same_extn_line r (RAY A B) :=
+  ⟨ray_toProj_eq_mk_pt_pt_toProj ha hb, ha⟩
 
 protected theorem refl (r : Ray P) : same_extn_line r r := ⟨rfl, .inl Ray.source_lies_on⟩
 
@@ -386,47 +386,47 @@ end DirLine
 
 namespace Line
 
-variable (A B : P) (h : B ≠ A) (ray : Ray P) (seg_nd : SegND P)
+variable (A B : P) [h : PtNe B A] (ray : Ray P) (seg_nd : SegND P)
 
 section pt_pt
 
-theorem line_of_pt_pt_eq_rev {A B : P} (h : B ≠ A) : LIN A B h = LIN B A h.symm :=
-  (Quotient.eq (r := same_extn_line.setoid)).mpr ⟨Ray.toProj_eq_toProj_of_mk_pt_pt h, .inl (Ray.snd_pt_lies_on_mk_pt_pt h)⟩
+theorem line_of_pt_pt_eq_rev {A B : P} [_h : PtNe B A] : LIN A B = LIN B A :=
+  (Quotient.eq (r := same_extn_line.setoid)).mpr ⟨Ray.toProj_eq_toProj_of_mk_pt_pt, .inl (Ray.snd_pt_lies_on_mk_pt_pt (B := B))⟩
 
-theorem fst_pt_lies_on_mk_pt_pt {A B : P} (h : B ≠ A) : A LiesOn LIN A B h := .inl Ray.source_lies_on
+theorem fst_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : A LiesOn LIN A B := .inl Ray.source_lies_on
 
-theorem snd_pt_lies_on_mk_pt_pt {A B : P} (h : B ≠ A) : B LiesOn LIN A B h := by
+theorem snd_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : B LiesOn LIN A B := by
   rw [line_of_pt_pt_eq_rev]
-  exact fst_pt_lies_on_mk_pt_pt h.symm
+  exact fst_pt_lies_on_mk_pt_pt
 
 -- The first point and the second point in Line.mk_pt_pt LiesOn the line it make.
-theorem pt_lies_on_line_of_pt_pt_of_ne {A B : P} (h: B ≠ A) : A LiesOn LIN A B h ∧ B LiesOn LIN A B h :=
-  ⟨fst_pt_lies_on_mk_pt_pt h, snd_pt_lies_on_mk_pt_pt h⟩
+theorem pt_lies_on_line_of_pt_pt_of_ne {A B : P} [_h : PtNe B A] : A LiesOn LIN A B ∧ B LiesOn LIN A B :=
+  ⟨fst_pt_lies_on_mk_pt_pt, snd_pt_lies_on_mk_pt_pt⟩
 
 -- two point determines a line
-theorem eq_line_of_pt_pt_of_ne {A B : P} {l : Line P} (h : B ≠ A) (ha : A LiesOn l) (hb : B LiesOn l) : LIN A B h = l := by
+theorem eq_line_of_pt_pt_of_ne {A B : P} {l : Line P} [_h : PtNe B A] (ha : A LiesOn l) (hb : B LiesOn l) : LIN A B = l := by
   revert l
   rintro ⟨r⟩ ha hb
-  exact (Quotient.eq (r := same_extn_line.setoid)).mpr (same_extn_line.symm ⟨ray_toProj_eq_mk_pt_pt_toProj h ha hb, ha⟩)
+  exact (Quotient.eq (r := same_extn_line.setoid)).mpr (same_extn_line.symm ⟨ray_toProj_eq_mk_pt_pt_toProj ha hb, ha⟩)
 
 -- If two lines have two distinct intersection points, then these two lines are identical.
-theorem eq_of_pt_pt_lies_on_of_ne {A B : P} (h : B ≠ A) {l₁ l₂ : Line P} (hA₁ : A LiesOn l₁) (hB₁ : B LiesOn l₁) (hA₂ : A LiesOn l₂) (hB₂ : B LiesOn l₂) : l₁ = l₂ := by
-  rw [← eq_line_of_pt_pt_of_ne h hA₁ hB₁]
-  exact eq_line_of_pt_pt_of_ne h hA₂ hB₂
+theorem eq_of_pt_pt_lies_on_of_ne {A B : P} [_h : PtNe B A] {l₁ l₂ : Line P} (hA₁ : A LiesOn l₁) (hB₁ : B LiesOn l₁) (hA₂ : A LiesOn l₂) (hB₂ : B LiesOn l₂) : l₁ = l₂ := by
+  rw [← eq_line_of_pt_pt_of_ne hA₁ hB₁]
+  exact eq_line_of_pt_pt_of_ne hA₂ hB₂
 
-theorem eq_pt_pt_line_iff_lies_on {A B : P} {l : Line P} (h : B ≠ A) : A LiesOn l ∧ B LiesOn l ↔ LIN A B h = l := by
-  refine' ⟨fun ⟨ha, hb⟩ ↦ eq_line_of_pt_pt_of_ne h ha hb, fun lAB ↦ _⟩
+theorem eq_pt_pt_line_iff_lies_on {A B : P} {l : Line P} [_h : PtNe B A] : A LiesOn l ∧ B LiesOn l ↔ LIN A B = l := by
+  refine' ⟨fun ⟨ha, hb⟩ ↦ eq_line_of_pt_pt_of_ne ha hb, fun lAB ↦ _⟩
   rw [← lAB]
-  exact pt_lies_on_line_of_pt_pt_of_ne h
+  exact pt_lies_on_line_of_pt_pt_of_ne
 
-theorem pt_pt_lies_on_iff_ray_toLine {A B : P} {l : Line P} (h : B ≠ A) : A LiesOn l ∧ B LiesOn l ↔ (RAY A B h).toLine = l :=
-  eq_pt_pt_line_iff_lies_on h
+theorem pt_pt_lies_on_iff_ray_toLine {A B : P} {l : Line P} [_h : PtNe B A] : A LiesOn l ∧ B LiesOn l ↔ (RAY A B).toLine = l :=
+  eq_pt_pt_line_iff_lies_on
 
-theorem pt_pt_lies_on_iff_seg_toLine {A B : P} {l : Line P} (h : B ≠ A) : A LiesOn l ∧ B LiesOn l ↔ (SEG_nd A B h).toLine = l :=
-  eq_pt_pt_line_iff_lies_on h
+theorem pt_pt_lies_on_iff_seg_toLine {A B : P} {l : Line P} [_h : PtNe B A] : A LiesOn l ∧ B LiesOn l ↔ (SEG_nd A B).toLine = l :=
+  eq_pt_pt_line_iff_lies_on
 
-theorem toProj_eq_seg_nd_toProj_of_lies_on {A B : P} {l : Line P} (ha : A LiesOn l) (hb : B LiesOn l) (hab : B ≠ A) : (SEG_nd A B hab).toProj = l.toProj := by
-  rw [← eq_line_of_pt_pt_of_ne hab ha hb]
+theorem toProj_eq_seg_nd_toProj_of_lies_on {A B : P} {l : Line P} (ha : A LiesOn l) (hb : B LiesOn l) [_hab : PtNe B A] : (SEG_nd A B).toProj = l.toProj := by
+  rw [← eq_line_of_pt_pt_of_ne ha hb]
   rfl
 
 end pt_pt
@@ -474,19 +474,19 @@ section pt_dir
 
 namespace DirLine
 
-variable (A B : P) (h : B ≠ A) (ray : Ray P) (seg_nd : SegND P)
+variable (A B : P) [_h : PtNe B A] (ray : Ray P) (seg_nd : SegND P)
 
-theorem pt_pt_rev_eq_rev {A B : P} (h : B ≠ A) : DLIN B A h.symm = (DLIN A B h).reverse := by
-  refine' (Quotient.eq (r := same_dir_line.setoid)).mpr ⟨_, .inl (Ray.snd_pt_lies_on_mk_pt_pt h.symm)⟩
+theorem pt_pt_rev_eq_rev {A B : P} [_h : PtNe B A] : DLIN B A = (DLIN A B).reverse := by
+  refine' (Quotient.eq (r := same_dir_line.setoid)).mpr ⟨_, .inl (Ray.snd_pt_lies_on_mk_pt_pt (B := A))⟩
   rw [Ray.toDir_of_rev_eq_neg_toDir, Ray.toDir_eq_neg_toDir_of_mk_pt_pt]
 
-theorem fst_pt_lies_on_mk_pt_pt {A B : P} (h : B ≠ A) : A LiesOn DLIN A B h := .inl Ray.source_lies_on
+theorem fst_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : A LiesOn DLIN A B := .inl Ray.source_lies_on
 
-theorem snd_pt_lies_on_mk_pt_pt {A B : P} (h : B ≠ A) : B LiesOn DLIN A B h := Line.snd_pt_lies_on_mk_pt_pt h
+theorem snd_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : B LiesOn DLIN A B := Line.snd_pt_lies_on_mk_pt_pt
 
 -- The first point and the second point in DirLine.mk_pt_pt LiesOn the directed line it make.
-theorem pt_lies_on_of_pt_pt_of_ne {A B : P} (h: B ≠ A) : A LiesOn DLIN A B h ∧ B LiesOn DLIN A B h :=
-  ⟨fst_pt_lies_on_mk_pt_pt h, snd_pt_lies_on_mk_pt_pt h⟩
+theorem pt_lies_on_of_pt_pt_of_ne {A B : P} [_h : PtNe B A] : A LiesOn DLIN A B ∧ B LiesOn DLIN A B :=
+  ⟨fst_pt_lies_on_mk_pt_pt, snd_pt_lies_on_mk_pt_pt⟩
 
 theorem pt_lies_on_of_mk_pt_dir (dir : Dir) : A LiesOn mk_pt_dir A dir :=
   Line.pt_lies_on_of_mk_pt_dir A dir
@@ -509,22 +509,22 @@ theorem mk_pt_dir_eq_of_eq_toDir {A : P} {l : DirLine P} (h : A LiesOn l) {x : D
 theorem eq_of_same_toDir_and_pt_lies_on {A : P} {l₁ l₂ : DirLine P} (h₁ : A LiesOn l₁) (h₂ : A LiesOn l₂) (h : l₁.toDir = l₂.toDir) : l₁ = l₂ := by
   rw [← mk_pt_dir_eq h₁, mk_pt_dir_eq_of_eq_toDir h₂ h]
 
-theorem eq_dirline_of_toDir_eq_of_pt_of_ne {A B : P} {l : DirLine P} (h : B ≠ A) (ha : A LiesOn l) (hd : (SEG_nd A B h).toDir = l.toDir) : DLIN A B h = l :=
-  eq_of_same_toDir_and_pt_lies_on (fst_pt_lies_on_mk_pt_pt h) ha hd
+theorem eq_dirline_of_toDir_eq_of_pt_of_ne {A B : P} {l : DirLine P} [_h : PtNe B A] (ha : A LiesOn l) (hd : (SEG_nd A B).toDir = l.toDir) : DLIN A B = l :=
+  eq_of_same_toDir_and_pt_lies_on fst_pt_lies_on_mk_pt_pt ha hd
 
-theorem eq_dirline_rev_of_toDir_ne_of_pt_pt_of_ne {A B : P} {l : DirLine P} (h : B ≠ A) (ha : A LiesOn l) (hb : B LiesOn l) (hd : (SEG_nd A B h).toDir ≠ l.toDir) : DLIN B A h.symm = l := by
-  refine' (Eq.trans _ (pt_pt_rev_eq_rev h).symm).symm
-  exact (eq_rev_of_toDir_ne_of_toLine_eq (Line.eq_line_of_pt_pt_of_ne h ha hb).symm hd.symm)
+theorem eq_dirline_rev_of_toDir_ne_of_pt_pt_of_ne {A B : P} {l : DirLine P} [_h : PtNe B A] (ha : A LiesOn l) (hb : B LiesOn l) (hd : (SEG_nd A B).toDir ≠ l.toDir) : DLIN B A = l := by
+  refine' (Eq.trans _ pt_pt_rev_eq_rev.symm).symm
+  exact (eq_rev_of_toDir_ne_of_toLine_eq (Line.eq_line_of_pt_pt_of_ne ha hb).symm hd.symm)
 
-theorem eq_dirline_or_rev_of_pt_pt_of_ne {A B : P} {l : DirLine P} (h : B ≠ A) (ha : A LiesOn l) (hb : B LiesOn l) : DLIN A B h = l ∨ DLIN B A h.symm = l :=
-  if hd : (SEG_nd A B h).toDir = l.toDir then (.inl (eq_dirline_of_toDir_eq_of_pt_of_ne h ha hd))
-  else (.inr (eq_dirline_rev_of_toDir_ne_of_pt_pt_of_ne h ha hb hd))
+theorem eq_dirline_or_rev_of_pt_pt_of_ne {A B : P} {l : DirLine P} [_h : PtNe B A] (ha : A LiesOn l) (hb : B LiesOn l) : DLIN A B = l ∨ DLIN B A = l :=
+  if hd : (SEG_nd A B).toDir = l.toDir then (.inl (eq_dirline_of_toDir_eq_of_pt_of_ne ha hd))
+  else (.inr (eq_dirline_rev_of_toDir_ne_of_pt_pt_of_ne ha hb hd))
 
-theorem eq_dirline_or_rev_of_pt_pt_lies_on_of_ne {A B : P} (h : B ≠ A) {l₁ l₂ : DirLine P} (hA₁ : A LiesOn l₁) (hB₁ : B LiesOn l₁) (hA₂ : A LiesOn l₂) (hB₂ : B LiesOn l₂) : l₁ = l₂ ∨ l₁ = l₂.reverse :=
-  eq_or_eq_rev_of_toLine_eq (Line.eq_of_pt_pt_lies_on_of_ne h hA₁ hB₁ hA₂ hB₂)
+theorem eq_dirline_or_rev_of_pt_pt_lies_on_of_ne {A B : P} [_h : PtNe B A] {l₁ l₂ : DirLine P} (hA₁ : A LiesOn l₁) (hB₁ : B LiesOn l₁) (hA₂ : A LiesOn l₂) (hB₂ : B LiesOn l₂) : l₁ = l₂ ∨ l₁ = l₂.reverse :=
+  eq_or_eq_rev_of_toLine_eq (Line.eq_of_pt_pt_lies_on_of_ne hA₁ hB₁ hA₂ hB₂)
 
-theorem toProj_eq_seg_nd_toProj_of_lies_on {A B : P} {l : DirLine P} (ha : A LiesOn l) (hb : B LiesOn l) (hab : B ≠ A) : (SEG_nd A B hab).toProj = l.toProj :=
-  (Line.toProj_eq_seg_nd_toProj_of_lies_on ha hb hab).trans l.toLine_toProj_eq_toProj
+theorem toProj_eq_seg_nd_toProj_of_lies_on {A B : P} {l : DirLine P} (ha : A LiesOn l) (hb : B LiesOn l) [_h : PtNe B A] : (SEG_nd A B).toProj = l.toProj :=
+  (Line.toProj_eq_seg_nd_toProj_of_lies_on ha hb).trans l.toLine_toProj_eq_toProj
 
 theorem exsit_dirline_pt_lies_on : ∃ l : DirLine P, A LiesOn l := by
   rcases Line.exsit_line_pt_lies_on A with ⟨⟨r⟩, h⟩
@@ -547,15 +547,15 @@ theorem Ray.toLine_eq_rev_toLine {r : Ray P} : r.toLine = r.reverse.toLine :=
 theorem SegND.toLine_eq_toray_toLine {s : SegND P} : s.toRay.toLine = s.toLine := rfl
 
 theorem SegND.toLine_eq_rev_toLine {s : SegND P} : s.toLine = s.reverse.toLine :=
-  line_of_pt_pt_eq_rev s.2
+  line_of_pt_pt_eq_rev (_h := ⟨s.2⟩)
 
 theorem SegND.toLine_eq_extn_toLine {s : SegND P} : s.toLine = s.extension.toLine :=
   (Quotient.eq (r := same_extn_line.setoid)).mpr ⟨ SegND.extn_toProj.symm,
   .inl (SegND.lies_on_toRay_of_lies_on Seg.target_lies_on)⟩
 
-theorem ray_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).toLine = LIN A B h := rfl
+theorem ray_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toLine = LIN A B := rfl
 
-theorem seg_nd_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} (h : B ≠ A) : (SEG_nd A B h).toLine = LIN A B h := rfl
+theorem seg_nd_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} [_h : PtNe B A] : (SEG_nd A B).toLine = LIN A B := rfl
 
 theorem Ray.toDirLine_rev_eq_rev_toLine {r : Ray P} : r.toDirLine.reverse = r.reverse.toDirLine :=
   (Quotient.eq (r := same_dir_line.setoid)).mpr ⟨rfl, .inl r.source_lies_on_rev⟩
@@ -563,16 +563,16 @@ theorem Ray.toDirLine_rev_eq_rev_toLine {r : Ray P} : r.toDirLine.reverse = r.re
 theorem SegND.toDirLine_eq_toray_toLine {s : SegND P} : s.toRay.toDirLine = s.toDirLine := rfl
 
 theorem SegND.toDirLine_rev_eq_rev_toLine {s : SegND P} : s.toDirLine.reverse = s.reverse.toDirLine :=
-  (eq_dirline_of_toDir_eq_of_pt_of_ne s.2.symm (DirLine.lies_on_rev_iff_lies_on.mpr target_lies_on_toDirLine)
+  (eq_dirline_of_toDir_eq_of_pt_of_ne (_h := ⟨s.2.symm⟩) (DirLine.lies_on_rev_iff_lies_on.mpr target_lies_on_toDirLine)
     ((s.toDir_of_rev_eq_neg_toDir).trans s.toDirLine.rev_toDir_eq_neg_toDir)).symm
 
 theorem SegND.toDirLine_eq_extn_toDirLine {s : SegND P} : s.toDirLine = s.extension.toDirLine :=
     (Quotient.eq (r := same_dir_line.setoid)).mpr
     ⟨s.extn_toDir, .inl (s.lies_on_toRay_of_lies_on s.1.target_lies_on)⟩
 
-theorem ray_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).toDirLine = DLIN A B h := rfl
+theorem ray_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toDirLine = DLIN A B := rfl
 
-theorem seg_nd_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} (h : B ≠ A) : (SEG_nd A B h).toDirLine = DLIN A B h := rfl
+theorem seg_nd_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} [_h : PtNe B A] : (SEG_nd A B).toDirLine = DLIN A B := rfl
 
 end coercion
 
@@ -644,12 +644,12 @@ theorem lies_on_iff_lies_on_iff_line_eq_line (l₁ l₂ : Line P) : (∀ A : P, 
   · revert l₁ l₂
     rintro ⟨r₁⟩ ⟨r₂⟩ h
     rcases r₁.toLine.nontriv with ⟨X, Y, Xrl₁, Yrl₁, neq⟩
-    exact eq_of_pt_pt_lies_on_of_ne neq Xrl₁ Yrl₁ ((h X).mp Xrl₁) ((h Y).mp Yrl₁)
+    exact eq_of_pt_pt_lies_on_of_ne (_h := ⟨neq⟩) Xrl₁ Yrl₁ ((h X).mp Xrl₁) ((h Y).mp Yrl₁)
   · exact fun h A ↦ Iff.of_eq (congrArg (lies_on A) h)
 
-theorem Line.lies_on_iff_eq_toProj_of_lies_on {A B : P} {l : Line P} (h : B ≠ A) (hA : A LiesOn l) : B LiesOn l ↔ (SEG_nd A B h).toProj = l.toProj := by
-  refine' ⟨fun hB ↦ toProj_eq_seg_nd_toProj_of_lies_on hA hB h, fun eq ↦ _⟩
-  rw [← eq_of_same_toProj_and_pt_lies_on (SegND.lies_on_toLine_of_lie_on (@Seg.source_lies_on _ _ (SEG_nd A B h).1)) hA eq]
+theorem Line.lies_on_iff_eq_toProj_of_lies_on {A B : P} {l : Line P} [_h : PtNe B A] (hA : A LiesOn l) : B LiesOn l ↔ (SEG_nd A B).toProj = l.toProj := by
+  refine' ⟨fun hB ↦ toProj_eq_seg_nd_toProj_of_lies_on hA hB, fun eq ↦ _⟩
+  rw [← eq_of_same_toProj_and_pt_lies_on (SegND.lies_on_toLine_of_lie_on (@Seg.source_lies_on _ _ (SEG_nd A B).1)) hA eq]
   exact SegND.lies_on_toLine_of_lie_on Seg.target_lies_on
 
 theorem Line.exist_real_vec_eq_smul_of_lies_on {A B : P} {dir : Dir} (h : B LiesOn (mk_pt_dir A dir)) : ∃ t : ℝ, VEC A B = t • dir.unitVec :=
@@ -657,10 +657,10 @@ theorem Line.exist_real_vec_eq_smul_of_lies_on {A B : P} {dir : Dir} (h : B Lies
 
 theorem Line.exist_real_vec_eq_smul_vec_of_lies_on {A B : P} {v : VecND} (hb : B LiesOn (mk_pt_vec_nd A v)) : ∃ t : ℝ, VEC A B = t • v.1 :=
   if h : VEC A B = 0 then ⟨0, h.trans (zero_smul ℝ v.1).symm⟩
-  else VecND.toProj_eq_toProj_iff.mp (toProj_eq_seg_nd_toProj_of_lies_on (pt_lies_on_of_mk_pt_vec_nd A v) hb (vsub_ne_zero.mp h))
+  else VecND.toProj_eq_toProj_iff.mp (toProj_eq_seg_nd_toProj_of_lies_on (pt_lies_on_of_mk_pt_vec_nd A v) hb (_hab := ⟨vsub_ne_zero.mp h⟩))
 
-theorem Line.exist_real_of_lies_on_of_pt_pt {A B C : P} (h : B ≠ A) (hc : C LiesOn (LIN A B h)) : ∃ t : ℝ, VEC A C = t • VEC A B :=
-  @exist_real_vec_eq_smul_vec_of_lies_on P _ A C (SEG_nd A B h).toVecND hc
+theorem Line.exist_real_of_lies_on_of_pt_pt {A B C : P} [_h : PtNe B A] (hc : C LiesOn (LIN A B)) : ∃ t : ℝ, VEC A C = t • VEC A B :=
+  @exist_real_vec_eq_smul_vec_of_lies_on P _ A C (SEG_nd A B).toVecND hc
 
 theorem Line.lies_on_of_exist_real_vec_eq_smul {A B : P} {dir : Dir} {t : ℝ} (h : VEC A B = t • dir.unitVec) : B LiesOn (mk_pt_dir A dir) :=
   (@pt_lies_on_line_from_ray_iff_vec_parallel P _ B ⟨A, dir⟩).mpr ⟨t, h⟩
@@ -671,8 +671,8 @@ theorem Line.lies_on_of_exist_real_vec_eq_smul_vec {A B : P} {v : VecND} {t : �
     rw [mul_smul, VecND.norm_smul_toDir_unitVec]
   lies_on_of_exist_real_vec_eq_smul h'
 
-theorem Line.lies_on_of_exist_real_of_pt_pt {A B C : P} (h : B ≠ A) {t : ℝ} (ht : VEC A C = t • VEC A B) : C LiesOn (LIN A B h) :=
-  @lies_on_of_exist_real_vec_eq_smul_vec P _ A C (SEG_nd A B h).toVecND t ht
+theorem Line.lies_on_of_exist_real_of_pt_pt {A B C : P} [_h : PtNe B A] {t : ℝ} (ht : VEC A C = t • VEC A B) : C LiesOn (LIN A B) :=
+  @lies_on_of_exist_real_vec_eq_smul_vec P _ A C (SEG_nd A B).toVecND t ht
 
 theorem Ray.subset_toDirLine {r : Ray P}: r.carrier ⊆ r.toDirLine.carrier := r.subset_toLine
 
@@ -702,8 +702,8 @@ theorem SegND.lies_on_toDirLine_of_lies_on_extn {X : P} {seg_nd : SegND P} (h : 
 theorem DirLine.lies_on_iff_lies_on_iff_toLine_eq_toLine (l₁ l₂ : DirLine P) : (∀ A : P, A LiesOn l₁ ↔ A LiesOn l₂) ↔ l₁.toLine = l₂.toLine :=
   lies_on_iff_lies_on_iff_line_eq_line l₁.toLine l₂.toLine
 
-theorem DirLine.lies_on_iff_eq_toProj_of_lies_on {A B : P} {l : DirLine P} (h : B ≠ A) (hA : A LiesOn l) : B LiesOn l ↔ (SEG_nd A B h).toProj = l.toProj :=
-  (Line.lies_on_iff_eq_toProj_of_lies_on h hA).trans (Eq.congr rfl l.toLine_toProj_eq_toProj)
+theorem DirLine.lies_on_iff_eq_toProj_of_lies_on {A B : P} {l : DirLine P} [_h : PtNe B A] (hA : A LiesOn l) : B LiesOn l ↔ (SEG_nd A B).toProj = l.toProj :=
+  (Line.lies_on_iff_eq_toProj_of_lies_on hA).trans (Eq.congr rfl l.toLine_toProj_eq_toProj)
 
 theorem DirLine.exist_real_vec_eq_smul_of_lies_on {A B : P} {dir : Dir} (h : B LiesOn (mk_pt_dir A dir)) : ∃ t : ℝ, VEC A B = t • dir.unitVec :=
   lies_on_or_rev_iff_exist_real_vec_eq_smul.mp h
@@ -711,8 +711,8 @@ theorem DirLine.exist_real_vec_eq_smul_of_lies_on {A B : P} {dir : Dir} (h : B L
 theorem DirLine.exist_real_vec_eq_smul_vec_of_lies_on {A B : P} {v : VecND} (h : B LiesOn (mk_pt_vec_nd A v)) : ∃ t : ℝ, VEC A B = t • v.1 :=
   Line.exist_real_vec_eq_smul_vec_of_lies_on h
 
-theorem DirLine.exist_real_of_lies_on_of_pt_pt {A B C : P} (h : B ≠ A) (hc : C LiesOn (DLIN A B h)) : ∃ t : ℝ, VEC A C = t • VEC A B :=
-  Line.exist_real_of_lies_on_of_pt_pt h hc
+theorem DirLine.exist_real_of_lies_on_of_pt_pt {A B C : P} [_h : PtNe B A] (hc : C LiesOn (DLIN A B)) : ∃ t : ℝ, VEC A C = t • VEC A B :=
+  Line.exist_real_of_lies_on_of_pt_pt hc
 
 theorem DirLine.exist_real_vec_eq_smul_toDir_of_lies_on {A B : P} {l : DirLine P} (ha : A LiesOn l) (hb : B LiesOn l) : ∃ t : ℝ, VEC A B = t • l.toDir.unitVec := by
   rw [← mk_pt_dir_eq ha]
@@ -725,8 +725,8 @@ theorem DirLine.lies_on_of_exist_real_vec_eq_smul {A B : P} {dir : Dir} {t : ℝ
 theorem DirLine.lies_on_of_exist_real_vec_eq_smul_vec {A B : P} {v : VecND} {t : ℝ} (h : VEC A B = t • v.1) : B LiesOn (mk_pt_vec_nd A v):=
   Line.lies_on_of_exist_real_vec_eq_smul_vec h
 
-theorem DirLine.lies_on_of_exist_real_of_pt_pt {A B C : P} (h : B ≠ A) {t : ℝ} (ht : VEC A C = t • VEC A B) : C LiesOn (DLIN A B h) :=
-  Line.lies_on_of_exist_real_of_pt_pt h ht
+theorem DirLine.lies_on_of_exist_real_of_pt_pt {A B C : P} [_h : PtNe B A] {t : ℝ} (ht : VEC A C = t • VEC A B) : C LiesOn (DLIN A B) :=
+  Line.lies_on_of_exist_real_of_pt_pt ht
 
 theorem DirLine.lies_on_of_exist_real_vec_eq_smul_toDir {A B : P} {l : DirLine P} (ha : A LiesOn l) {t : ℝ} (ht : VEC A B = t • l.toDir.unitVec) : B LiesOn l := by
   rw [← mk_pt_dir_eq ha]
@@ -740,12 +740,14 @@ section colinear
 
 namespace Line
 
-theorem pt_pt_linear {A B C : P} (h : B ≠ A) (hc : C LiesOn (LIN A B h) ) : colinear A B C :=
+theorem pt_pt_linear {A B C : P} [_h : PtNe B A] (hc : C LiesOn (LIN A B)) : colinear A B C :=
   if hcb : C = B then colinear_of_trd_eq_snd A hcb
   else if hac : A = C then colinear_of_fst_eq_snd B hac
-  else perm_colinear_trd_fst_snd <| (dite_prop_iff_or _).mpr <| .inr ⟨by push_neg; exact ⟨hac, h, hcb⟩,
-    ((lies_on_iff_eq_toProj_of_lies_on hcb (snd_pt_lies_on_mk_pt_pt h)).mp hc).trans <|
-      congrArg toProj (line_of_pt_pt_eq_rev h)⟩
+  else
+    haveI : PtNe C B := ⟨hcb⟩
+    perm_colinear_trd_fst_snd <| (dite_prop_iff_or _).mpr <| .inr ⟨by push_neg; exact ⟨hac, Fact.out, hcb⟩,
+    ((lies_on_iff_eq_toProj_of_lies_on snd_pt_lies_on_mk_pt_pt).mp hc).trans <|
+      congrArg toProj line_of_pt_pt_eq_rev⟩
 
 theorem linear {l : Line P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) (h₃ : C LiesOn l) : colinear A B C := by
   revert l
@@ -807,43 +809,47 @@ theorem linear {l : Line P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) 
       | inr c =>
         exact Ray.colinear_of_lies_on a b c
 
-theorem pt_pt_maximal {A B C : P} (h : B ≠ A) (Co : colinear A B C) : C LiesOn (LIN A B h) :=
+theorem pt_pt_maximal {A B C : P} [_h : PtNe B A] (Co : colinear A B C) : C LiesOn (LIN A B) :=
   if hcb : C = B then by
     rw [hcb]
-    exact snd_pt_lies_on_mk_pt_pt h
-  else (lies_on_iff_eq_toProj_of_lies_on hcb (snd_pt_lies_on_mk_pt_pt h)).mpr <|
-    (toProj_eq_of_colinear hcb h.symm (perm_colinear_snd_trd_fst Co)).trans <|
-      congrArg Line.toProj (line_of_pt_pt_eq_rev h).symm
+    exact snd_pt_lies_on_mk_pt_pt
+  else
+    haveI : PtNe C B := ⟨hcb⟩
+    (lies_on_iff_eq_toProj_of_lies_on snd_pt_lies_on_mk_pt_pt).mpr <|
+    (toProj_eq_of_colinear (perm_colinear_snd_trd_fst Co)).trans <|
+      congrArg Line.toProj (line_of_pt_pt_eq_rev (_h := _h)).symm
 
-theorem maximal {l : Line P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) (h : B ≠ A) (Co : colinear A B C) : C LiesOn l := by
-  rw [← eq_line_of_pt_pt_of_ne h h₁ h₂]
-  exact pt_pt_maximal h Co
+theorem maximal {l : Line P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) [_h : PtNe B A] (Co : colinear A B C) : C LiesOn l := by
+  rw [← eq_line_of_pt_pt_of_ne h₁ h₂]
+  exact pt_pt_maximal Co
 
-theorem lies_on_line_of_pt_pt_iff_colinear {A B : P} (h : B ≠ A) (X : P) : (X LiesOn (LIN A B h)) ↔ colinear A B X := ⟨
-  fun hx ↦ (LIN A B h).linear (fst_pt_lies_on_mk_pt_pt h) (snd_pt_lies_on_mk_pt_pt h) hx,
-  fun c ↦ (LIN A B h).maximal (fst_pt_lies_on_mk_pt_pt h) (snd_pt_lies_on_mk_pt_pt h) h c⟩
+theorem lies_on_line_of_pt_pt_iff_colinear {A B : P} [_h : PtNe B A] (X : P) : (X LiesOn (LIN A B)) ↔ colinear A B X := ⟨
+  fun hx ↦ (LIN A B).linear fst_pt_lies_on_mk_pt_pt snd_pt_lies_on_mk_pt_pt hx,
+  fun c ↦ (LIN A B).maximal fst_pt_lies_on_mk_pt_pt snd_pt_lies_on_mk_pt_pt c⟩
 
 -- This is also a typical proof that shows how to use linear, maximal, nontriv of a line. Please write it shorter in future.
 
-theorem lies_on_iff_colinear_of_ne_lies_on_lies_on {A B : P} {l : Line P} (h : B ≠ A) (ha : A LiesOn l) (hb : B LiesOn l) (C : P) : (C LiesOn l) ↔ colinear A B C :=
-  ⟨fun hc ↦ l.linear ha hb hc, fun c ↦ l.maximal ha hb h c⟩
+theorem lies_on_iff_colinear_of_ne_lies_on_lies_on {A B : P} {l : Line P} [_h : PtNe B A] (ha : A LiesOn l) (hb : B LiesOn l) (C : P) : (C LiesOn l) ↔ colinear A B C :=
+  ⟨fun hc ↦ l.linear ha hb hc, fun c ↦ l.maximal ha hb c⟩
 
 theorem colinear_iff_exist_line_lies_on (A B C : P) : colinear A B C ↔ ∃ l : Line P, (A LiesOn l) ∧ (B LiesOn l) ∧ (C LiesOn l) := by
   constructor
   · intro c
-    by_cases h : B ≠ A
-    · exact ⟨(LIN A B h), fst_pt_lies_on_mk_pt_pt h, snd_pt_lies_on_mk_pt_pt h,
-        (lies_on_line_of_pt_pt_iff_colinear h C).mpr c⟩
-    rw [ne_eq, not_not] at h
-    by_cases hh : C ≠ B
-    · use LIN B C hh
+    by_cases h : PtNe B A
+    · exact ⟨LIN A B, fst_pt_lies_on_mk_pt_pt, snd_pt_lies_on_mk_pt_pt,
+        (lies_on_line_of_pt_pt_iff_colinear C).mpr c⟩
+    rw [PtNe, fact_iff, ne_eq, not_not] at h
+    by_cases hh : PtNe C B
+    · use LIN B C hh.out
       rw [← h, and_self_left]
-      exact ⟨fst_pt_lies_on_mk_pt_pt hh, snd_pt_lies_on_mk_pt_pt hh⟩
-    rw [ne_eq, not_not] at hh
+      exact ⟨fst_pt_lies_on_mk_pt_pt, snd_pt_lies_on_mk_pt_pt⟩
+    rw [PtNe, fact_iff, ne_eq, not_not] at hh
     simp only [hh, h, and_self, exsit_line_pt_lies_on A]
   · intro ⟨l, ha, hb, hc⟩
-    if h : B = A then simp only [h, colinear, or_true, dite_true]
-    else exact (lies_on_iff_colinear_of_ne_lies_on_lies_on h ha hb C).mp hc
+    if h : PtNe B A then exact (lies_on_iff_colinear_of_ne_lies_on_lies_on ha hb C).mp hc
+    else
+      simp [PtNe, fact_iff] at h
+      simp only [h, colinear, or_true, dite_true]
 
 end Line
 
@@ -852,17 +858,17 @@ namespace DirLine
 theorem linear {l : DirLine P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) (h₃ : C LiesOn l) : colinear A B C :=
   Line.linear h₁ h₂ h₃
 
-theorem pt_pt_maximal {A B C : P} (h : B ≠ A) (Co : colinear A B C) : C LiesOn (DLIN A B h) :=
-  Line.pt_pt_maximal h Co
+theorem pt_pt_maximal {A B C : P} [_h : PtNe B A] (Co : colinear A B C) : C LiesOn (DLIN A B) :=
+  Line.pt_pt_maximal Co
 
-theorem maximal {l : DirLine P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) (h : B ≠ A) (Co : colinear A B C) : C LiesOn l :=
-  Line.maximal  h₁ h₂ h Co
+theorem maximal {l : DirLine P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) [_h : PtNe B A] (Co : colinear A B C) : C LiesOn l :=
+  Line.maximal h₁ h₂ Co
 
-theorem lies_on_dirline_of_pt_pt_iff_colinear {A B : P} (h : B ≠ A) (X : P) : (X LiesOn (DLIN A B h)) ↔ colinear A B X :=
-  Line.lies_on_line_of_pt_pt_iff_colinear h X
+theorem lies_on_dirline_of_pt_pt_iff_colinear {A B : P} [_h : PtNe B A] (X : P) : (X LiesOn (DLIN A B)) ↔ colinear A B X :=
+  Line.lies_on_line_of_pt_pt_iff_colinear X
 
-theorem lies_on_iff_colinear_of_ne_lies_on_lies_on {A B : P} {l : DirLine P} (h : B ≠ A) (ha : A LiesOn l) (hb : B LiesOn l) (C : P) : (C LiesOn l) ↔ colinear A B C :=
-  Line.lies_on_iff_colinear_of_ne_lies_on_lies_on h ha hb C
+theorem lies_on_iff_colinear_of_ne_lies_on_lies_on {A B : P} {l : DirLine P} [_h : PtNe B A] (ha : A LiesOn l) (hb : B LiesOn l) (C : P) : (C LiesOn l) ↔ colinear A B C :=
+  Line.lies_on_iff_colinear_of_ne_lies_on_lies_on ha hb C
 
 theorem colinear_iff_exist_dirline_lies_on (A B C : P) : colinear A B C ↔ ∃ l : Line P, (A LiesOn l) ∧ (B LiesOn l) ∧ (C LiesOn l) :=
   Line.colinear_iff_exist_line_lies_on A B C
@@ -882,21 +888,21 @@ theorem exists_ne_pt_pt_lies_on (A : P) {l : Line P} : ∃ B : P, B LiesOn l ∧
   rcases l.nontriv with ⟨X, Y, hx, hy, ne⟩
   exact if h : A = X then ⟨Y, hy, ne.trans_eq h.symm⟩ else ⟨X, hx, ne_comm.mp h⟩
 
-theorem lies_on_of_SegND_toProj_eq_toProj {A B : P} {l : Line P} (ha : A LiesOn l) (hab : B ≠ A) (hp : (SEG_nd A B hab).toProj = l.toProj) : B LiesOn l :=
-  (lies_on_iff_eq_toProj_of_lies_on hab ha).mpr hp
+theorem lies_on_of_SegND_toProj_eq_toProj {A B : P} {l : Line P} (ha : A LiesOn l) [_hab : PtNe B A] (hp : (SEG_nd A B).toProj = l.toProj) : B LiesOn l :=
+  (lies_on_iff_eq_toProj_of_lies_on ha).mpr hp
 
-theorem vec_vadd_pt_lies_on_line {A B : P} {l : Line P} (hA : A LiesOn l) (hB : B LiesOn l) (h : B ≠ A) : (VEC A B) +ᵥ B LiesOn l := by
-  rw [← eq_line_of_pt_pt_of_ne h hA hB]
+theorem vec_vadd_pt_lies_on_line {A B : P} {l : Line P} (hA : A LiesOn l) (hB : B LiesOn l) [_h : PtNe B A] : (VEC A B) +ᵥ B LiesOn l := by
+  rw [← eq_line_of_pt_pt_of_ne hA hB]
   refine' Ray.lies_on_toLine_iff_lies_on_or_lies_on_rev.mpr
     (.inl ⟨2 * ‖VEC A B‖, mul_nonneg zero_le_two (norm_nonneg (VEC A B)), _⟩)
   have eq : VEC A (VEC A B +ᵥ B) = (2 : ℝ) • (VEC A B) := (vadd_vsub_assoc _ B A).trans (two_smul _ _).symm
   simp [Ray.mk_pt_pt, eq, mul_smul]
 
-theorem exist_pt_beyond_pt_right {A B : P} {l : Line P} (hA : A LiesOn l) (hB : B LiesOn l) (h : B ≠ A) : ∃ C : P, C LiesOn l ∧ B LiesInt (SEG A C) :=
-  ⟨VEC A B +ᵥ B, vec_vadd_pt_lies_on_line hA hB h, (SEG_nd A B h).target_lies_int_seg_source_vec_vadd_target⟩
+theorem exist_pt_beyond_pt_right {A B : P} {l : Line P} (hA : A LiesOn l) (hB : B LiesOn l) [_h : PtNe B A] : ∃ C : P, C LiesOn l ∧ B LiesInt (SEG A C) :=
+  ⟨VEC A B +ᵥ B, vec_vadd_pt_lies_on_line hA hB, (SEG_nd A B).target_lies_int_seg_source_vec_vadd_target⟩
 
-theorem exist_pt_beyond_pt_left {A B : P} {l : Line P} (hA : A LiesOn l) (hB : B LiesOn l) (h : B ≠ A) : ∃ C : P, C LiesOn l ∧ A LiesInt (SEG C B) := by
-  rcases exist_pt_beyond_pt_right hB hA h.symm with ⟨C, cl, acb⟩
+theorem exist_pt_beyond_pt_left {A B : P} {l : Line P} (hA : A LiesOn l) (hB : B LiesOn l) [_h : PtNe B A] : ∃ C : P, C LiesOn l ∧ A LiesInt (SEG C B) := by
+  rcases exist_pt_beyond_pt_right hB hA with ⟨C, cl, acb⟩
   exact ⟨C, cl, Seg.lies_int_rev_iff_lies_int.mp acb⟩
 
 end Line
@@ -907,14 +913,14 @@ namespace DirLine
 theorem exists_ne_pt_pt_lies_on (A : P) {l : DirLine P} : ∃ B : P, B LiesOn l ∧ B ≠ A :=
   l.toLine.exists_ne_pt_pt_lies_on A
 
-theorem lies_on_of_SegND_toProj_eq_toProj {A B : P} {l : DirLine P} (ha : A LiesOn l) (hab : B ≠ A) (hp : (SEG_nd A B hab).toDir = l.toDir) : B LiesOn l :=
-  Line.lies_on_of_SegND_toProj_eq_toProj ha hab ((congrArg Dir.toProj hp).trans l.toLine_toProj_eq_toProj.symm)
+theorem lies_on_of_SegND_toProj_eq_toProj {A B : P} {l : DirLine P} (ha : A LiesOn l) [_hab : PtNe B A] (hp : (SEG_nd A B).toDir = l.toDir) : B LiesOn l :=
+  Line.lies_on_of_SegND_toProj_eq_toProj ha ((congrArg Dir.toProj hp).trans l.toLine_toProj_eq_toProj.symm)
 
-theorem exist_pt_beyond_pt_right {A B : P} {l : DirLine P} (hA : A LiesOn l) (hB : B LiesOn l) (h : B ≠ A) : ∃ C : P, C LiesOn l ∧ B LiesInt (SEG A C) :=
-  Line.exist_pt_beyond_pt_right hA hB h
+theorem exist_pt_beyond_pt_right {A B : P} {l : DirLine P} (hA : A LiesOn l) (hB : B LiesOn l) [_h : PtNe B A] : ∃ C : P, C LiesOn l ∧ B LiesInt (SEG A C) :=
+  Line.exist_pt_beyond_pt_right hA hB
 
-theorem exist_pt_beyond_pt_left {A B : P} {l : DirLine P} (hA : A LiesOn l) (hB : B LiesOn l) (h : B ≠ A) : ∃ C : P, C LiesOn l ∧ A LiesInt (SEG C B) :=
-  Line.exist_pt_beyond_pt_left hA hB h
+theorem exist_pt_beyond_pt_left {A B : P} {l : DirLine P} (hA : A LiesOn l) (hB : B LiesOn l) [_h : PtNe B A] : ∃ C : P, C LiesOn l ∧ A LiesInt (SEG C B) :=
+  Line.exist_pt_beyond_pt_left hA hB
 
 end DirLine
 

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Line_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Line_trash.lean
@@ -5,17 +5,17 @@ namespace EuclidGeom
 
 variable {P : Type _} [EuclideanPlane P]
 
-theorem same_dist_eq_or_eq_neg {A B C : P} (hne : B ≠ A) (h : C LiesOn (LIN A B hne)) (heq : dist A C = dist A B) : (C = B) ∨ (VEC A C = VEC B A) := by
-  have : LIN A B hne = (RAY A B hne).toLine := rfl
+theorem same_dist_eq_or_eq_neg {A B C : P} [hne : PtNe B A] (h : C LiesOn (LIN A B)) (heq : dist A C = dist A B) : (C = B) ∨ (VEC A C = VEC B A) := by
+  have : LIN A B = (RAY A B).toLine := rfl
   rw [this] at h
   rcases Ray.lies_on_toLine_iff_lies_on_or_lies_on_rev.mp h with h | h
   · left; apply (eq_iff_vec_eq_zero _ _).mpr
-    have : VEC A C = (dist A C) • (RAY A B hne).2.unitVec := Ray.lieson_eq_dist h
+    have : VEC A C = (dist A C) • (RAY A B).2.unitVec := Ray.lieson_eq_dist h
     calc
       _ = VEC A C - VEC A B := by rw [vec_sub_vec]
-      _ = (dist A B) • (RAY A B hne).2.unitVec - VEC A B := by rw [this, heq]
-      _ = (dist A B) • (RAY A B hne).2.unitVec - ‖VEC_nd A B hne‖ • (VEC_nd A B hne).toDir.unitVec := by simp
-      _ = (dist A B) • (RAY A B hne).2.unitVec - ‖VEC_nd A B hne‖ • (RAY A B hne).2.unitVec := rfl
+      _ = (dist A B) • (RAY A B).2.unitVec - VEC A B := by rw [this, heq]
+      _ = (dist A B) • (RAY A B).2.unitVec - ‖VEC_nd A B‖ • (VEC_nd A B).toDir.unitVec := by simp
+      _ = (dist A B) • (RAY A B).2.unitVec - ‖VEC_nd A B‖ • (RAY A B).2.unitVec := rfl
       _ = 0 := by
         rw [← sub_smul, dist_comm, NormedAddTorsor.dist_eq_norm']
         simp
@@ -24,19 +24,19 @@ theorem same_dist_eq_or_eq_neg {A B C : P} (hne : B ≠ A) (h : C LiesOn (LIN A 
 
   right
   calc
-    _ = (dist A C) • (RAY A B hne).reverse.2.unitVec := Ray.lieson_eq_dist h
-    _ = (dist A C) • (- (VEC_nd A B hne).toDir.unitVec) := by simp
-    _ = (dist A B) • (- (VEC_nd A B hne).toDir.unitVec) := by rw [heq]
-    _ = - (‖VEC_nd A B hne‖ • (VEC_nd A B hne).toDir.unitVec) := by
+    _ = (dist A C) • (RAY A B).reverse.2.unitVec := Ray.lieson_eq_dist h
+    _ = (dist A C) • (- (VEC_nd A B).toDir.unitVec) := by simp
+    _ = (dist A B) • (- (VEC_nd A B).toDir.unitVec) := by rw [heq]
+    _ = - (‖VEC_nd A B‖ • (VEC_nd A B).toDir.unitVec) := by
       rw [smul_neg, dist_comm, NormedAddTorsor.dist_eq_norm']
       rfl
-    _ = - (VEC_nd A B hne).1 := by simp
+    _ = - (VEC_nd A B).1 := by simp
     _ = - VEC A B := rfl
     _ = VEC B A := by rw [neg_vec]
 
-theorem distinct_pts_same_dist_vec_eq {A B C : P} (hne₁ : B ≠ A) (hne₂ : C ≠ B) (h : C LiesOn (LIN A B hne₁)) (heq : dist A C = dist A B) : VEC B A = VEC A C := by
-  rcases same_dist_eq_or_eq_neg hne₁ h heq with hh | hh
-  · exfalso; tauto
+theorem distinct_pts_same_dist_vec_eq {A B C : P} [hne₁ : PtNe B A] [hne₂ : PtNe C B] (h : C LiesOn (LIN A B)) (heq : dist A C = dist A B) : VEC B A = VEC A C := by
+  rcases same_dist_eq_or_eq_neg h heq with rfl | hh
+  · exact absurd rfl hne₂.out
   exact hh.symm
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Parallel.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Parallel.lean
@@ -354,7 +354,7 @@ theorem inx_eq_of_same_extn_line {a₁ b₁ a₂ b₂ : Ray P} (g₁ : same_extn
   rw [ray_toLine_eq_of_same_extn_line g₁] at ha1
   rw [ray_toLine_eq_of_same_extn_line g₂] at hb1
   by_contra hn
-  have heq : a₂.toLine = b₂.toLine := eq_of_pt_pt_lies_on_of_ne hn
+  have heq : a₂.toLine = b₂.toLine := eq_of_pt_pt_lies_on_of_ne (_h := ⟨hn⟩)
     (inx_lies_on_fst_extn_line a₂ b₂ h₂) ha1 (inx_lies_on_snd_extn_line a₂ b₂ h₂) hb1
   exact h₂ (congrArg Line.toProj heq)
 
@@ -397,7 +397,7 @@ section property
 
 /-- Two unparallel lines have only one intersection point -/
 theorem unique_of_inx_of_line_of_not_para {A B : P} {l₁ l₂ : Line P} (h : ¬ l₁ ∥ l₂) (a : is_inx A l₁ l₂) (b : is_inx B l₁ l₂) : B = A :=
-  Classical.byContradiction fun d ↦ h (congrArg Line.toProj (eq_of_pt_pt_lies_on_of_ne d a.1 b.1 a.2 b.2))
+  Classical.byContradiction fun d ↦ h (congrArg Line.toProj (eq_of_pt_pt_lies_on_of_ne (_h := ⟨d⟩) a.1 b.1 a.2 b.2))
 
 /-- Given two unparallel line $l_1$ $l_2$, the point given by function "Line.inx" is exactly the intersection of these two lines -/
 theorem inx_of_line_eq_inx {A : P} {l₁ l₂ : Line P} (h : ¬ l₁ ∥ l₂) (ha : is_inx A l₁ l₂) :
@@ -415,8 +415,10 @@ theorem eq_of_parallel_and_pt_lies_on {A : P} {l₁ l₂ : Line P} (h₁ : A Lie
 theorem exists_intersection_of_nonparallel_lines {l₁ l₂ : Line P} (h : ¬ l₁ ∥ l₂) : ∃ p : P, p LiesOn l₁ ∧ p LiesOn l₂ := by
   rcases l₁.nontriv with ⟨A, ⟨B, hab⟩⟩
   rcases l₂.nontriv with ⟨C, ⟨D, hcd⟩⟩
-  have e' : (SEG_nd A B hab.2.2).toProj ≠ (SEG_nd C D hcd.2.2).toProj := by
-    rw [toProj_eq_seg_nd_toProj_of_lies_on hab.1 hab.2.1 hab.2.2, toProj_eq_seg_nd_toProj_of_lies_on hcd.1 hcd.2.1 hcd.2.2]
+  haveI : PtNe B A := ⟨hab.2.2⟩
+  haveI : PtNe D C := ⟨hcd.2.2⟩
+  have e' : (SEG_nd A B).toProj ≠ (SEG_nd C D).toProj := by
+    rw [toProj_eq_seg_nd_toProj_of_lies_on hab.1 hab.2.1, toProj_eq_seg_nd_toProj_of_lies_on hcd.1 hcd.2.1]
     exact h
   let x := cu (VEC A B) (VEC C D) (VEC A C)
   let y := cv (VEC A B) (VEC C D) (VEC A C)
@@ -425,9 +427,9 @@ theorem exists_intersection_of_nonparallel_lines {l₁ l₂ : Line P} (h : ¬ l�
   have h : VEC C (x • VEC A B +ᵥ A) = - y • VEC C D := by
     rw [← vec_sub_vec A _ _, vec_of_pt_vadd_pt_eq_vec _ _, e]
     simp only [Complex.real_smul, sub_add_cancel', neg_smul]
-  exact ⟨x • VEC A B +ᵥ A, (lies_on_iff_colinear_of_ne_lies_on_lies_on hab.2.2 hab.1 hab.2.1 _).2
+  exact ⟨x • VEC A B +ᵥ A, (lies_on_iff_colinear_of_ne_lies_on_lies_on hab.1 hab.2.1 _).2
     (colinear_of_vec_eq_smul_vec (vec_of_pt_vadd_pt_eq_vec A _)),
-    (lies_on_iff_colinear_of_ne_lies_on_lies_on hcd.2.2 hcd.1 hcd.2.1 _).2 (colinear_of_vec_eq_smul_vec h)⟩
+    (lies_on_iff_colinear_of_ne_lies_on_lies_on hcd.1 hcd.2.1 _).2 (colinear_of_vec_eq_smul_vec h)⟩
 
 /-- If two lines are not parallel, then there exists a unique point in their intersection -/
 theorem exists_unique_intersection_of_nonparallel_lines {l₁ l₂ : Line P} (h : ¬ l₁ ∥ l₂) : ∃! p : P, p LiesOn l₁ ∧ p LiesOn l₂ := by
@@ -435,7 +437,7 @@ theorem exists_unique_intersection_of_nonparallel_lines {l₁ l₂ : Line P} (h 
   use X
   simp only [h₁, h₂, and_self, and_imp, true_and]
   exact fun _ h₁' h₂' ↦ Classical.byContradiction fun n ↦
-    h (congrArg toProj (eq_of_pt_pt_lies_on_of_ne n h₁ h₁' h₂ h₂'))
+    h (congrArg toProj (eq_of_pt_pt_lies_on_of_ne (_h := ⟨n⟩) h₁ h₁' h₂ h₂'))
 
 scoped notation "LineInx" => Line.inx
 

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Perpendicular.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Perpendicular.lean
@@ -84,7 +84,7 @@ theorem perp_foot_ne_self_iff_not_lies_on (A : P) (l : Line P) : perp_foot A l �
   (perp_foot_eq_self_iff_lies_on A l).not
 
 theorem line_of_self_perp_foot_eq_perp_line_of_not_lies_on {A : P} {l : Line P} (h : ¬ A LiesOn l) : LIN A (perp_foot A l) ((perp_foot_ne_self_iff_not_lies_on A l).2 h) = perp_line A l :=
-  eq_line_of_pt_pt_of_ne ((perp_foot_ne_self_iff_not_lies_on A l).2 h) (pt_lies_on_of_mk_pt_proj A l.toProj.perp) (Line.inx_is_inx (toProj_ne_perp_toProj A l)).2
+  eq_line_of_pt_pt_of_ne (_h := ⟨(perp_foot_ne_self_iff_not_lies_on A l).2 h⟩) (pt_lies_on_of_mk_pt_proj A l.toProj.perp) (Line.inx_is_inx (toProj_ne_perp_toProj A l)).2
 
 theorem line_of_self_perp_foot_perp_line_of_not_lies_on {A : P} {l : Line P} (h : ¬ (A LiesOn l)) : LIN A (perp_foot A l) ((perp_foot_ne_self_iff_not_lies_on A l).2 h) ⟂ l :=
   (congrArg toProj (line_of_self_perp_foot_eq_perp_line_of_not_lies_on h)).trans (perp_line_perp A l)

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ratio.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ratio.lean
@@ -17,11 +17,11 @@ def divratio (A B C : P) (colin : colinear A B C) (cnea : C ≠ A) : ℝ := (Dir
 
 def divratio (A B C : P) : ℝ := ((VEC A B)/(VEC A C)).1
 
-theorem ratio_is_real' (A B C : P) (colin : colinear A B C) (cnea : C ≠ A) : ((VEC A B)/(VEC A C)).2 = 0 := by
+theorem ratio_is_real' (A B C : P) (colin : colinear A B C) [cnea : PtNe C A] : ((VEC A B)/(VEC A C)).2 = 0 := by
   have h0 : colinear A C B := flip_colinear_snd_trd colin
-  rw [colinear_iff_eq_smul_vec_of_ne cnea] at h0
+  rw [colinear_iff_eq_smul_vec_of_ne] at h0
   rcases h0 with ⟨r , h1⟩
-  have h2 : VEC A C ≠ 0 := (ne_iff_vec_ne_zero A C).mp cnea
+  have h2 : VEC A C ≠ 0 := (ne_iff_vec_ne_zero A C).mp cnea.out
   rw [h1]
   calc
     (r • VEC A C / VEC A C).im = ((r : ℂ) • VEC A C / VEC A C).im := rfl
@@ -29,23 +29,23 @@ theorem ratio_is_real' (A B C : P) (colin : colinear A B C) (cnea : C ≠ A) : (
       rw [Vec.smul_cdiv_cancel _ h2]
       rfl
 
-theorem ratio_is_real (A B C : P) (colin : colinear A B C) (cnea : C ≠ A) : (VEC A B)/(VEC A C) = divratio A B C := by
+theorem ratio_is_real (A B C : P) (colin : colinear A B C) [cnea : PtNe C A] : (VEC A B)/(VEC A C) = divratio A B C := by
   have h0 : (divratio A B C : ℂ).re = ((VEC A B)/(VEC A C)).re := rfl
   have h1 : (divratio A B C : ℂ).im = ((VEC A B)/(VEC A C)).im := by
-    rw [ratio_is_real' A B C colin cnea]
+    rw [ratio_is_real' A B C colin]
     simp
   exact Complex.ext h0 h1.symm
 
-theorem vec_eq_vec_smul_ratio (A B C : P) (colin : colinear A B C) (cnea : C ≠ A) : VEC A B = (divratio A B C) • (VEC A C) := by
-  have h0 : VEC A C ≠ 0 := (ne_iff_vec_ne_zero A C).mp cnea
+theorem vec_eq_vec_smul_ratio (A B C : P) (colin : colinear A B C) [cnea : PtNe C A] : VEC A B = (divratio A B C) • (VEC A C) := by
+  have h0 : VEC A C ≠ 0 := (ne_iff_vec_ne_zero A C).mp cnea.out
   have h1 : VEC A B = ((VEC A B) / (VEC A C)) • VEC A C := by
     field_simp
-  rw [h1, ratio_is_real A B C colin cnea]
+  rw [h1, ratio_is_real A B C colin]
   field_simp
 
-theorem ratio_eq_ratio_div_ratio_minus_one (A B C : P) (cnea : C ≠ A) (colin : colinear A B C) : divratio B A C = (divratio A B C) / (divratio A B C - 1) := by
+theorem ratio_eq_ratio_div_ratio_minus_one (A B C : P) [cnea : PtNe C A] (colin : colinear A B C) : divratio B A C = (divratio A B C) / (divratio A B C - 1) := by
   have h0 : VEC B A = (-divratio A B C) • VEC A C := by
-    rw [← neg_vec A B, vec_eq_vec_smul_ratio A B C colin cnea]
+    rw [← neg_vec A B, vec_eq_vec_smul_ratio A B C colin]
     field_simp
   have h1 : VEC B C = (1 - divratio A B C) • VEC A C := by
     rw [← vec_add_vec B A C, h0]
@@ -58,7 +58,7 @@ theorem ratio_eq_ratio_div_ratio_minus_one (A B C : P) (cnea : C ≠ A) (colin :
     rw[h3]
   have h4 : VEC B A / VEC B C = (((divratio A B C / (divratio A B C - 1)) : ℝ ) : ℂ) := by
     rw [h0, h1]
-    have h5 : VEC A C ≠ 0 := (ne_iff_vec_ne_zero A C).mp cnea
+    have h5 : VEC A C ≠ 0 := (ne_iff_vec_ne_zero A C).mp cnea.out
     field_simp
     norm_cast
     rw [Vec.neg_cdiv, Vec.smul_cdiv, Vec.cdiv_self h5, neg_div, ← div_neg]
@@ -69,11 +69,11 @@ theorem ratio_eq_ratio_div_ratio_minus_one (A B C : P) (cnea : C ≠ A) (colin :
   rw [h4]
   rw [Complex.ofReal_re]
 
-theorem pt_eq_of_ratio_eq_of_ne_ne (A B C D : P) (cned : C ≠ D) (dnea : D ≠ A) (dneb : D ≠ B) (colinacd : colinear A C D) (colinbcd : colinear B C D) (req : divratio A C D = divratio B C D) : A = B := by
+theorem pt_eq_of_ratio_eq_of_ne_ne (A B C D : P) [cned : PtNe C D] [dnea : PtNe D A] [dneb : PtNe D B] (colinacd : colinear A C D) (colinbcd : colinear B C D) (req : divratio A C D = divratio B C D) : A = B := by
   have h0 : divratio C A D = divratio C B D := by
-    rw [ratio_eq_ratio_div_ratio_minus_one A C D dnea colinacd, req, ratio_eq_ratio_div_ratio_minus_one B C D dneb colinbcd]
+    rw [ratio_eq_ratio_div_ratio_minus_one A C D colinacd, req, ratio_eq_ratio_div_ratio_minus_one B C D colinbcd]
   have h1 : VEC C A = VEC C B := by
-    rw [vec_eq_vec_smul_ratio C A D (flip_colinear_fst_snd colinacd) cned.symm, vec_eq_vec_smul_ratio C B D (flip_colinear_fst_snd colinbcd) cned.symm, h0]
+    rw [vec_eq_vec_smul_ratio C A D (flip_colinear_fst_snd colinacd), vec_eq_vec_smul_ratio C B D (flip_colinear_fst_snd colinbcd), h0]
   rw [← start_vadd_vec_eq_end C A, h1, start_vadd_vec_eq_end C B]
 
 theorem ratio_eq_zero_of_point_eq1 (A B : P) : divratio A A B = 0 := by

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
@@ -272,10 +272,10 @@ instance : IntFig (SegND P) P where
 end SegND
 
 @[simp]
-lemma Ray.mkPtPt_toDir (A B : P) (h : B ≠ A) : (RAY A B h).toDir = (VEC_nd A B h).toDir := rfl
+lemma Ray.mkPtPt_toDir (A B : P) [_h : PtNe B A] : (RAY A B).toDir = (VEC_nd A B).toDir := rfl
 
 @[simp]
-lemma SegND.mkPtPt_toDir (A B : P) (h : B ≠ A) : (SEG_nd A B h).toDir = (VEC_nd A B h).toDir := rfl
+lemma SegND.mkPtPt_toDir (A B : P) [_h : PtNe B A] : (SEG_nd A B).toDir = (VEC_nd A B).toDir := rfl
 
 end coersion
 
@@ -304,18 +304,18 @@ theorem toVec_eq_zero_of_deg {l : Seg P} : (l.target = l.source) ↔ l.toVec = 0
   rw [Seg.toVec, Vec.mkPtPt, vsub_eq_zero_iff_eq]
 
 /-- Given two distinct points $A$ and $B$, the direction of ray $AB$ is same as the negative direction of ray $BA$ -/
-theorem Ray.toDir_eq_neg_toDir_of_mk_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).toDir = -(RAY B A h.symm).toDir := by
+theorem Ray.toDir_eq_neg_toDir_of_mk_pt_pt {A B : P} [h : PtNe B A] : (RAY A B).toDir = -(RAY B A).toDir := by
   simp only [Ray.mk_pt_pt, ne_eq]
   rw [← VecND.neg_toDir, ← VecND.mk_neg]
   congr
   rw [neg_vec]
 
 /-- Given two distinct points $A$ and $B$, the projective direction of ray $AB$ is same as that of ray $BA$. -/
-theorem Ray.toProj_eq_toProj_of_mk_pt_pt {A B : P} (h : B ≠ A) : (RAY A B h).toProj = (RAY B A h.symm).toProj :=
-  Dir.toProj_eq_toProj_iff.mpr (.inr (toDir_eq_neg_toDir_of_mk_pt_pt h))
+theorem Ray.toProj_eq_toProj_of_mk_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toProj = (RAY B A).toProj :=
+  Dir.toProj_eq_toProj_iff.mpr (.inr toDir_eq_neg_toDir_of_mk_pt_pt)
 
 /-- Given two distinct points $A$ and $B$, the ray associated to the segment $AB$ is same as ray $AB$. -/
-theorem pt_pt_seg_toRay_eq_pt_pt_ray {A B : P} (h : B ≠ A) : (SegND.mk A B h).toRay = Ray.mk_pt_pt A B h := rfl
+theorem pt_pt_seg_toRay_eq_pt_pt_ray {A B : P} [_h : PtNe B A] : (SEG_nd A B).toRay = RAY A B := rfl
 
 /-- Given a segment $AB$, $AB$ is nondegenerate if and only if vector  $\overrightarrow{AB}$ is nonzero. -/
 theorem Seg.IsND_iff_toVec_ne_zero {l : Seg P} : l.IsND ↔ l.toVec ≠ 0 := toVec_eq_zero_of_deg.not
@@ -489,13 +489,13 @@ theorem SegND.lies_int_toRay_of_lies_int {X : P} {seg_nd : SegND P} (h : X LiesI
   ⟨SegND.lies_on_toRay_of_lies_on h.1, h.2.1⟩
 
 /-- Given two distinct points $A$ and $B$, $B$ lies on the ray $AB$. -/
-theorem Ray.snd_pt_lies_on_mk_pt_pt {A B : P} (h : B ≠ A) : B LiesOn (RAY A B h) := by
-  show B LiesOn (SEG_nd A B h).toRay
+theorem Ray.snd_pt_lies_on_mk_pt_pt {A B : P} [h : PtNe B A] : B LiesOn (RAY A B) := by
+  show B LiesOn (SEG_nd A B).toRay
   exact SegND.lies_on_toRay_of_lies_on Seg.target_lies_on
 
 /-- Given two distinct points $A$ and $B$, $B$ lies in the interior of the ray $AB$. -/
-theorem Ray.snd_pt_lies_int_mk_pt_pt (A B : P) (h : B ≠ A) : B LiesInt (RAY A B h) :=
-  ⟨snd_pt_lies_on_mk_pt_pt h, h⟩
+theorem Ray.snd_pt_lies_int_mk_pt_pt (A B : P) [h : PtNe B A] : B LiesInt (RAY A B) :=
+  ⟨snd_pt_lies_on_mk_pt_pt, h.out⟩
 
 /-- Given a point $A$ on a ray, the direction of the ray is the same as the direction from the source of the ray to $A$. -/
 theorem Ray.pt_pt_toDir_eq_ray_toDir {ray : Ray P} {A : P} (h : A LiesInt ray) : (RAY ray.1 A h.2).toDir = ray.toDir := by
@@ -775,7 +775,7 @@ def SegND.reverse (seg_nd : SegND P) : SegND P := ⟨seg_nd.1.reverse, nd_of_rev
 
 /-- The reverse of a nondegenerate segment $AB$ is the nondegenerate segment $BA$. -/
 @[simp]
-theorem seg_nd_rev {A B : P} (h : B ≠ A) : (SEG_nd A B h).reverse = SEG_nd B A h.symm := rfl
+theorem seg_nd_rev {A B : P} [_h : PtNe B A] : (SEG_nd A B).reverse = SEG_nd B A := rfl
 
 /-- Given a nondegenerate segment, first viewing it as a segment and then reversing it is the same as first reversing it and then viewing it as a segment. -/
 @[simp]
@@ -1085,17 +1085,16 @@ theorem lies_on_or_rev_iff_exist_real_vec_eq_smul {A : P} {ray : Ray P} : (A Lie
     exact ⟨-t, neg_nonneg.mpr k.le, hu⟩
 
 /-- Given two distinct points $A$ and $B$ and a ray, if both $A$ and $B$ lies on the ray or its reversed ray, then the projective direction of the ray is the same as the projective direction of the ray $AB$. -/
-theorem ray_toProj_eq_mk_pt_pt_toProj {A B : P} {ray : Ray P} (h : B ≠ A) (ha : A LiesOn ray ∨ A LiesOn ray.reverse) (hb : B LiesOn ray ∨ B LiesOn ray.reverse) : ray.toProj = (RAY A B h).toProj := by
+theorem ray_toProj_eq_mk_pt_pt_toProj {A B : P} {ray : Ray P} [h : PtNe B A] (ha : A LiesOn ray ∨ A LiesOn ray.reverse) (hb : B LiesOn ray ∨ B LiesOn ray.reverse) : ray.toProj = (RAY A B).toProj := by
   rcases lies_on_or_rev_iff_exist_real_vec_eq_smul.mp ha with ⟨ta, eqa⟩
   rcases lies_on_or_rev_iff_exist_real_vec_eq_smul.mp hb with ⟨tb, eqb⟩
   have heq : VEC A B = (tb - ta) • ray.2.unitVecND := by rw [← vec_sub_vec _ A B, eqa, eqb, sub_smul]
-  have h0 : tb - ta ≠ 0 := (smul_ne_zero_iff.mp (heq.symm.trans_ne (vsub_ne_zero.mpr h))).1
+  have h0 : tb - ta ≠ 0 := (smul_ne_zero_iff.mp (heq.symm.trans_ne (vsub_ne_zero.mpr Fact.out))).1
   apply Dir.toProj_eq_toProj_iff_unitVec.mpr
-  use (tb - ta)⁻¹ * ‖VEC_nd A B h‖
+  use (tb - ta)⁻¹ * ‖VEC_nd A B‖
   simp [← (inv_smul_eq_iff₀ h0).mpr heq, Units.smul_def, mul_smul]
 
 end reverse
-
 
 section extension
 /-!

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle.lean
@@ -52,9 +52,55 @@ def value_of_angle_of_three_point_nd (A O B : P) (h₁ : A ≠ O) (h₂ : B ≠ 
 
 def value_of_angle_of_two_ray_of_eq_source (start_ray end_ray : Ray P) (h : start_ray.source = end_ray.source) : AngValue := (Angle.mk start_ray end_ray h).value
 
-scoped notation "ANG" => Angle.mk_pt_pt_pt
+@[inherit_doc Angle.mk_pt_pt_pt]
+scoped syntax "ANG" ws term:max ws term:max ws term:max (ws term:max ws term:max)? : term
 
-scoped notation "∠" => value_of_angle_of_three_point_nd
+macro_rules
+  | `(ANG $A $B $C) => `(Angle.mk_pt_pt_pt $A $B $C (@Fact.out _ inferInstance) (@Fact.out _ inferInstance))
+  | `(ANG $A $B $C $h₁ $h₂) => `(Angle.mk_pt_pt_pt $A $B $C $h₁ $h₂)
+
+open Lean PrettyPrinter.Delaborator SubExpr in
+/-- Delaborator for `Angle.mk_pt_pt_pt` -/
+@[delab app.EuclidGeom.Angle.mk_pt_pt_pt]
+def delabAngleMkPtPtPt : Delab := do
+  let e ← getExpr
+  guard $ e.isAppOfArity' ``Angle.mk_pt_pt_pt 7
+  let A ← withNaryArg 2 delab
+  let B ← withNaryArg 3 delab
+  let C ← withNaryArg 4 delab
+  let ⟨b₁, h₁⟩ ← withNaryArg 5 do
+    return ((← getExpr).isAppOfArity' ``Fact.out 2, ← delab)
+  let ⟨b₂, h₂⟩ ← withNaryArg 6 do
+    return ((← getExpr).isAppOfArity' ``Fact.out 2, ← delab)
+  if b₁ && b₂ then
+    `(ANG $A $B $C)
+  else
+    `(ANG $A $B $C $h₁ $h₂)
+
+@[inherit_doc value_of_angle_of_three_point_nd]
+scoped syntax "∠" ws term:max ws term:max ws term:max (ws term:max ws term:max)? : term
+
+macro_rules
+  | `(∠ $A $B $C) => `(value_of_angle_of_three_point_nd $A $B $C (@Fact.out _ inferInstance) (@Fact.out _ inferInstance))
+  | `(∠ $A $B $C $h₁ $h₂) => `(value_of_angle_of_three_point_nd $A $B $C $h₁ $h₂)
+
+open Lean PrettyPrinter.Delaborator SubExpr in
+/-- Delaborator for `value_of_angle_of_three_point_nd` -/
+@[delab app.EuclidGeom.value_of_angle_of_three_point_nd]
+def delabValueOfAngleOfThreePointND : Delab := do
+  let e ← getExpr
+  guard $ e.isAppOfArity' ``value_of_angle_of_three_point_nd 7
+  let A ← withNaryArg 2 delab
+  let B ← withNaryArg 3 delab
+  let C ← withNaryArg 4 delab
+  let ⟨b₁, h₁⟩ ← withNaryArg 5 do
+    return ((← getExpr).isAppOfArity' ``Fact.out 2, ← delab)
+  let ⟨b₂, h₂⟩ ← withNaryArg 6 do
+    return ((← getExpr).isAppOfArity' ``Fact.out 2, ← delab)
+  if b₁ && b₂ then
+    `(∠ $A $B $C)
+  else
+    `(∠ $A $B $C $h₁ $h₂)
 
 namespace Angle
 

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle_trash.lean
@@ -11,17 +11,17 @@ theorem end_ray_toDir_rev_toDir_of_ang_rev_ang {ang₁ ang₂ : Angle P} (hs : a
 
 theorem start_ray_toDir_rev_toDir_of_ang_rev_ang {ang₁ ang₂ : Angle P} (hs : ang₁.end_ray.toDir = (ang₂.end_ray).reverse.toDir) (h : ang₁.value = ang₂.value) : ang₁.start_ray.toDir = (ang₂.start_ray).reverse.toDir := sorry
 
-theorem angle_value_eq_angle (A : P) (ray : Ray P) (h : A ≠ ray.1) : (Angle.mk_ray_pt ray A h).value = VecND.angle ray.2.unitVecND (VEC_nd ray.source A h) := sorry
+theorem angle_value_eq_angle (A : P) (ray : Ray P) [h : PtNe A ray.1] : (Angle.mk_ray_pt ray A h.out).value = VecND.angle ray.2.unitVecND (VEC_nd ray.source A) := sorry
 
 theorem ang_eq_ang_of_toDir_rev_toDir {ang₁ ang₂ : Angle P} (hs : ang₁.start_ray.toDir = - ang₂.start_ray.toDir) (he : ang₁.end_ray.toDir = - ang₂.end_ray.toDir) : ang₁.value = ang₂.value := sorry
 
-theorem eq_ang_of_lies_int_liesint {A A' B B' O: P} (h₁ : A ≠ O) (h₂ : B ≠ O) (h₁' : A' ≠ O) (h₂' : B' ≠ O) (LiesInt1 : A' LiesInt (RAY O A h₁) )  (LiesInt2 :  B' LiesInt (RAY O B h₂) ) : ANG A O B h₁ h₂ = ANG A' O B' h₁' h₂' := sorry
+theorem eq_ang_of_lies_int_liesint {A A' B B' O: P} [h₁ : PtNe A O] [h₂ : PtNe B O] [h₁' : PtNe A' O] [h₂' : PtNe B' O] (LiesInt1 : A' LiesInt (RAY O A) )  (LiesInt2 :  B' LiesInt (RAY O B) ) : ANG A O B = ANG A' O B' := sorry
 
-theorem eq_ang_value_of_lies_int_lies_int {A A' B B' O: P} (h₁ : A ≠ O) (h₂ : B ≠ O) (h₁' : A' ≠ O) (h₂' : B' ≠ O) (LiesInt1 : A' LiesInt (RAY O A h₁) )  (LiesInt2 :  B' LiesInt (RAY O B h₂) ) : ∠  A O B h₁ h₂ = ∠  A' O B' h₁' h₂' := sorry
+theorem eq_ang_value_of_lies_int_lies_int {A A' B B' O: P} [h₁ : PtNe A O] [h₂ : PtNe B O] [h₁' : PtNe A' O] [h₂' : PtNe B' O] (LiesInt1 : A' LiesInt (RAY O A) )  (LiesInt2 :  B' LiesInt (RAY O B) ) : ∠  A O B = ∠  A' O B' := sorry
 
-theorem eq_ang_val_of_lieson_lieson {A A' B B' O: P} (h₁ : A ≠ O) (h₂ : B ≠ O) (h₁' : A' ≠ O) (h₂' : B' ≠ O) (LiesInt1 : A' LiesInt (RAY O A h₁) )  (LiesInt2 :  B' LiesInt (RAY O B h₂) ) : ∠  A O B h₁ h₂ = ∠  A' O B' h₁' h₂' := sorry
+theorem eq_ang_val_of_lieson_lieson {A A' B B' O: P} [h₁ : PtNe A O] [h₂ : PtNe B O] [h₁' : PtNe A' O] [h₂' : PtNe B' O] (LiesInt1 : A' LiesInt (RAY O A) )  (LiesInt2 :  B' LiesInt (RAY O B) ) : ∠  A O B = ∠  A' O B' := sorry
 --Nailin Guan
-theorem neg_value_of_rev_ang {A B O: P} (h₁ : A ≠ O) (h₂ : B ≠ O) : ∠ A O B h₁ h₂ = -∠ B O A h₂ h₁ := sorry
+theorem neg_value_of_rev_ang {A B O: P} [h₁ : PtNe A O] [h₂ : PtNe B O] : ∠ A O B = -∠ B O A := sorry
 
 namespace Angle
 

--- a/EuclideanGeometry/Foundation/Axiom/Position/Orientation.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Orientation.lean
@@ -35,25 +35,25 @@ theorem wedge231 (A B C : P) : wedge B C A = wedge A B C := by rw [wedge312, wed
 
 theorem wedge321 (A B C : P) : wedge C B A = - wedge A B C := by rw [wedge213, wedge231]
 
-theorem wedge_eq_length_mul_length_mul_sin (A B C : P) (bnea : B ≠ A) (cnea : C ≠ A) : wedge A B C = (SEG A B).length * (SEG A C).length * sin (Angle.mk_pt_pt_pt B A C bnea cnea).value := by
+theorem wedge_eq_length_mul_length_mul_sin (A B C : P) [bnea : PtNe B A] [cnea : PtNe C A] : wedge A B C = (SEG A B).length * (SEG A C).length * sin (ANG B A C).value := by
   unfold wedge
-  have h0 : (Angle.mk_pt_pt_pt B A C bnea cnea).value = VecND.angle (VEC_nd A B bnea) (VEC_nd A C cnea)  := rfl
+  have h0 : (ANG B A C).value = VecND.angle (VEC_nd A B) (VEC_nd A C)  := rfl
   rw [h0]
-  exact (VecND.norm_mul_sin (VEC_nd A B bnea) (VEC_nd A C cnea)).symm
+  exact (VecND.norm_mul_sin (VEC_nd A B) (VEC_nd A C)).symm
 
 theorem colinear_iff_wedge_eq_zero (A B C : P) : (colinear A B C) ↔ (wedge A B C = 0) := by
   dsimp only [wedge]
-  by_cases h : B ≠ A
+  by_cases h : PtNe B A
   · have vecabnd : VEC A B ≠ 0 := by
-      exact (ne_iff_vec_ne_zero A B).mp h
+      exact (ne_iff_vec_ne_zero A B).mp h.out
     rw [← Vec.det_skew, neg_eq_zero, Vec.det_eq_zero_iff_eq_smul_right]
     simp only [vecabnd, false_or]
     constructor
     · intro k
-      exact (colinear_iff_eq_smul_vec_of_ne h).mp k
+      exact colinear_iff_eq_smul_vec_of_ne.mp k
     · intro k
-      exact (colinear_iff_eq_smul_vec_of_ne h).mpr k
-  · simp at h
+      exact colinear_iff_eq_smul_vec_of_ne.mpr k
+  · simp [PtNe, fact_iff] at h
     have vecab0 : VEC A B = 0 := by
       exact (eq_iff_vec_eq_zero A B).mp h
     constructor
@@ -75,13 +75,13 @@ theorem wedge_pos_iff_angle_pos (A B C : P) (nd : ¬colinear A B C) : (0 < wedge
       exact length_pos_iff_nd.mpr (acnd)
   constructor
   · intro h0
-    rw [wedge_eq_length_mul_length_mul_sin A B C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm] at h0
+    rw [wedge_eq_length_mul_length_mul_sin (bnea := ⟨(ne_of_not_colinear nd).2.2⟩) (cnea := ⟨(ne_of_not_colinear nd).2.1.symm⟩)] at h0
     have h3 : 0 < sin (Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm).value := by
       field_simp at h0
       exact h0
     rw [sin_pos_iff_angle_pos] at h3
     exact h3
-  rw [wedge_eq_length_mul_length_mul_sin A B C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm]
+  rw [wedge_eq_length_mul_length_mul_sin (bnea := ⟨(ne_of_not_colinear nd).2.2⟩) (cnea := ⟨(ne_of_not_colinear nd).2.1.symm⟩)]
   intro h0
   have h3 : 0 < sin ((Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm).value) := (sin_pos_iff_angle_pos (Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm)).mpr h0
   field_simp
@@ -99,23 +99,24 @@ theorem odist'_eq_zero_iff_exist_real_vec_eq_smul {A : P} {ray : Ray P} : odist'
   rw [Vec.det_eq_zero_iff_eq_smul_left]
   simp
 
-theorem odist'_eq_length_mul_sin (A : P) (ray : Ray P) (h : A ≠ ray.source) : odist' A ray = (SEG ray.source A).length * sin ((Angle.mk_ray_pt ray A h).value) := by
+theorem odist'_eq_length_mul_sin (A : P) (ray : Ray P) [h : PtNe A ray.source] : odist' A ray = (SEG ray.source A).length * sin ((Angle.mk_ray_pt ray A h.out).value) := by
   rw [odist',Angle.value]
-  have h0 : (Angle.mk_ray_pt ray A h).value = VecND.angle ray.2.unitVecND (VEC_nd ray.source A h) := angle_value_eq_angle A ray h
-  have h2 : (VEC_nd ray.source A h).1 = VEC ray.source A := rfl
+  have h0 : (Angle.mk_ray_pt ray A h.out).value = VecND.angle ray.2.unitVecND (VEC_nd ray.source A) := angle_value_eq_angle A ray
+  have h2 : (VEC_nd ray.source A).1 = VEC ray.source A := rfl
   have h3 : ‖ray.toDir.unitVecND‖ = 1 := by simp
-  have h4 : (SEG ray.source A).length = ‖VEC_nd ray.source A h‖ := rfl
-  rw [← h2, ← VecND.norm_mul_sin ray.2.unitVecND (VEC_nd ray.source A h),h3,h4,← h0]
+  have h4 : (SEG ray.source A).length = ‖VEC_nd ray.source A‖ := rfl
+  rw [← h2, ← VecND.norm_mul_sin ray.2.unitVecND (VEC_nd ray.source A),h3,h4,← h0]
   ring_nf
   rfl
 
-theorem wedge_eq_length_mul_odist' (A B C : P) (bnea : B ≠ A) : (wedge A B C) = (SEG A B).length * odist' C (RAY A B bnea) := by
+theorem wedge_eq_length_mul_odist' (A B C : P) [bnea : PtNe B A] : (wedge A B C) = (SEG A B).length * odist' C (RAY A B) := by
   by_cases p : C = A
-  · have vecrayc0 : VEC (RAY A B bnea).source C = 0 := (eq_iff_vec_eq_zero A C).mp p
+  · have vecrayc0 : VEC (RAY A B).source C = 0 := (eq_iff_vec_eq_zero A C).mp p
     dsimp only [wedge, odist']
     field_simp [(eq_iff_vec_eq_zero A C).mp p, vecrayc0]
-  · rw [wedge_eq_length_mul_length_mul_sin A B C bnea p,
-      odist'_eq_length_mul_sin C (RAY A B bnea), ← mul_assoc]
+  · haveI cnea : PtNe C A := ⟨p⟩
+    rw [wedge_eq_length_mul_length_mul_sin,
+      @odist'_eq_length_mul_sin _ _ C (RAY A B) cnea, ← mul_assoc]
     rfl
 
 
@@ -162,11 +163,11 @@ theorem odist_reverse_eq_neg_odist {α} (A : P) [DirFig α P] (df : α) : odist 
   rw [odist_reverse_eq_neg_odist'' A (toDirLine df)]
   rfl
 
-theorem wedge_eq_wedge_iff_odist_eq_odist_of_ne (A B C D : P) (bnea : B ≠ A) : (odist C (SEG_nd A B bnea) = odist D (SEG_nd A B bnea)) ↔ (wedge A B C = wedge A B D) := by
-  rw [wedge_eq_length_mul_odist' A B C bnea, wedge_eq_length_mul_odist' A B D bnea]
+theorem wedge_eq_wedge_iff_odist_eq_odist_of_ne (A B C D : P) [bnea : PtNe B A] : (odist C (SEG_nd A B) = odist D (SEG_nd A B)) ↔ (wedge A B C = wedge A B D) := by
+  rw [wedge_eq_length_mul_odist' A B C, wedge_eq_length_mul_odist' A B D]
   have h0 : 0 ≠ Seg.length (SEG A B) := by
     rw [length_ne_zero_iff_nd]
-    exact bnea
+    exact bnea.out
   field_simp
   tauto
 
@@ -233,25 +234,25 @@ end point_toray
 
 section oriented_area
 
-theorem oarea_eq_length_mul_odist_div_two (A B C : P) (bnea : B ≠ A) : oarea A B C = (SEG A B).length * odist C (SEG_nd A B bnea) / 2 := by
+theorem oarea_eq_length_mul_odist_div_two (A B C : P) [bnea : PtNe B A] : oarea A B C = (SEG A B).length * odist C (SEG_nd A B) / 2 := by
   unfold oarea
-  rw [wedge_eq_length_mul_odist' A B C bnea]
-  have h0 : toDirLine (SEG_nd A B bnea) = toDirLine (RAY A B bnea) := rfl
-  have h1 : odist C (RAY A B bnea) = odist C (SEG_nd A B bnea) := by
+  rw [wedge_eq_length_mul_odist' A B C]
+  have h0 : toDirLine (SEG_nd A B) = toDirLine (RAY A B) := rfl
+  have h1 : odist C (RAY A B) = odist C (SEG_nd A B) := by
     unfold odist
     rw[h0]
-  have h2 : odist C (RAY A B bnea) = odist' C (RAY A B bnea) := rfl
+  have h2 : odist C (RAY A B) = odist' C (RAY A B) := rfl
   rw [h2] at h1
   rw [h1]
 
-theorem oarea_eq_oarea_iff_odist_eq_odist_of_ne (A B C D : P) (bnea : B ≠ A) : odist C (SEG_nd A B bnea) = odist D (SEG_nd A B bnea) ↔ oarea A B C = oarea A B D := by
+theorem oarea_eq_oarea_iff_odist_eq_odist_of_ne (A B C D : P) [bnea : PtNe B A] : odist C (SEG_nd A B) = odist D (SEG_nd A B) ↔ oarea A B C = oarea A B D := by
   unfold oarea
   field_simp
-  exact wedge_eq_wedge_iff_odist_eq_odist_of_ne A B C D bnea
+  exact wedge_eq_wedge_iff_odist_eq_odist_of_ne A B C D
 
-theorem oarea_eq_sin_mul_length_mul_length_div_two (A B C : P) (bnea : B ≠ A) (cnea : C ≠ A) : oarea A B C = (SEG A B).length * (SEG A C).length * sin (Angle.mk_pt_pt_pt B A C bnea cnea).value / 2 := by
+theorem oarea_eq_sin_mul_length_mul_length_div_two (A B C : P) [bnea : PtNe B A] [cnea : PtNe C A] : oarea A B C = (SEG A B).length * (SEG A C).length * sin (ANG B A C).value / 2 := by
   unfold oarea
-  rw [wedge_eq_length_mul_length_mul_sin A B C bnea cnea]
+  rw [wedge_eq_length_mul_length_mul_sin A B C]
 
 theorem oarea_eq_zero_iff_colinear (A B C : P) : oarea A B C = 0 ↔ colinear A B C := by
   unfold oarea
@@ -266,17 +267,17 @@ end oriented_area
 
 section cooperation_with_parallel
 
-theorem odist_eq_odist_of_parallel' (A B : P) (ray : Ray P) (bnea : B ≠ A) (para : parallel (SEG_nd A B bnea) ray) : odist A ray =odist B ray := by
+theorem odist_eq_odist_of_parallel' (A B : P) (ray : Ray P) [bnea : PtNe B A] (para : parallel (SEG_nd A B) ray) : odist A ray =odist B ray := by
   unfold odist
   have h1 : Vec.det ray.2.unitVec (VEC ray.1 B) = Vec.det ray.2.unitVec (VEC ray.1 A) + Vec.det ray.2.unitVec (VEC A B)
   · rw [← map_add, ←vec_add_vec ray.1 A B]
   have h2 : Vec.det ray.2.unitVec (VEC A B) = 0
   · unfold parallel at para
-    have h3 : Dir.toProj ray.2 = (VEC_nd A B bnea).toProj := para.symm
-    have h4 : VecND.toProj ray.2.unitVecND = (VEC_nd A B bnea).toProj := by
+    have h3 : Dir.toProj ray.2 = (VEC_nd A B).toProj := para.symm
+    have h4 : VecND.toProj ray.2.unitVecND = (VEC_nd A B).toProj := by
       rw [← h3]
       simp
-    have := VecND.det_eq_zero_iff_toProj_eq_toProj (u := ray.toDir.unitVecND) (v := VEC_nd A B bnea)
+    have := VecND.det_eq_zero_iff_toProj_eq_toProj (u := ray.toDir.unitVecND) (v := VEC_nd A B)
     dsimp at this
     rw [this]
     exact h4
@@ -284,13 +285,13 @@ theorem odist_eq_odist_of_parallel' (A B : P) (ray : Ray P) (bnea : B ≠ A) (pa
   rw [add_zero] at h1
   exact h1.symm
 
-theorem odist_eq_odist_of_parallel {α} [DirFig α P] (A B : P) (df : α) (bnea : B ≠ A) (para : parallel (SegND.mk A B bnea) df) : odist A df = odist B df := sorry
+theorem odist_eq_odist_of_parallel {α} [DirFig α P] (A B : P) (df : α) [bnea : PtNe B A] (para : parallel (SEG_nd A B) df) : odist A df = odist B df := sorry
 
-theorem wedge_eq_wedge_iff_parallel_of_ne_ne (A B C D : P) (bnea : B ≠ A) (dnec : D ≠ C) : (parallel (SegND.mk A B bnea) (SegND.mk C D dnec)) ↔ wedge A B C = wedge A B D := sorry
+theorem wedge_eq_wedge_iff_parallel_of_ne_ne (A B C D : P) [bnea : PtNe B A] [dnec : PtNe D C] : (parallel (SEG_nd A B) (SEG_nd C D)) ↔ wedge A B C = wedge A B D := sorry
 
-theorem odist_eq_odist_iff_parallel_ne {α} [DirFig α P] (A B : P) (df : α) (bnea : B ≠ A) : (parallel (SegND.mk A B bnea) df) ↔ odist A df = odist B df := sorry
+theorem odist_eq_odist_iff_parallel_ne {α} [DirFig α P] (A B : P) (df : α) [bnea : PtNe B A] : (parallel (SEG_nd A B) df) ↔ odist A df = odist B df := sorry
 
-theorem oarea_eq_oarea_iff_parallel_ne (A B C D : P) (bnea : B ≠ A) (dnec : D ≠ C) : (parallel (SegND.mk A B bnea) (SegND.mk C D dnec)) ↔ oarea A B C = oarea A B D := sorry
+theorem oarea_eq_oarea_iff_parallel_ne (A B C D : P) [bnea : PtNe B A] [dnec : PtNe D C] : (parallel (SEG_nd A B) (SEG_nd C D)) ↔ oarea A B C = oarea A B D := sorry
 
 end cooperation_with_parallel
 
@@ -299,9 +300,9 @@ scoped infix : 50 " LiesOnRight " => IsOnRightSide
 
 section handside
 
-theorem same_sign_of_parallel (A B : P) (ray : Ray P) (bnea : B ≠ A) (para : parallel (RAY A B bnea)  ray) : odist_sign A ray = odist_sign B ray := by
+theorem same_sign_of_parallel (A B : P) (ray : Ray P) [bnea : PtNe B A] (para : parallel (RAY A B)  ray) : odist_sign A ray = odist_sign B ray := by
   unfold odist_sign
-  rw [odist_eq_odist_of_parallel' A B ray bnea para]
+  rw [odist_eq_odist_of_parallel' A B ray para]
 
 theorem same_odist_sign_of_same_odist_sign (A B : P) (l : DirLine P) (signeq : odist_sign A l = odist_sign B l) : ∀ (C : P) , Seg.IsOn C (SEG A B) → odist_sign C l = odist_sign A l := sorry
 

--- a/EuclideanGeometry/Foundation/Axiom/Position/Orientation_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Orientation_trash.lean
@@ -4,13 +4,13 @@ namespace EuclidGeom
 
 variable {P : Type _} [EuclideanPlane P]
 
-lemma liesonleft_ne_pts {A B C : P} (hne : B ≠ A) (h : C LiesOnLeft (DLIN A B hne)) : (C ≠ A) ∧ (C ≠ B) := sorry
+lemma liesonleft_ne_pts {A B C : P} [hne : PtNe B A] (h : C LiesOnLeft (DLIN A B)) : (C ≠ A) ∧ (C ≠ B) := sorry
 
-theorem liesonleft_angle_ispos {A B C : P} (hne : B ≠ A) (h : C LiesOnLeft (DLIN A B hne)) : (∠ A C B (liesonleft_ne_pts hne h).1.symm (liesonleft_ne_pts hne h).2.symm).IsPos := sorry
+theorem liesonleft_angle_ispos {A B C : P} [hne : PtNe B A] (h : C LiesOnLeft (DLIN A B)) : (∠ A C B (liesonleft_ne_pts h).1.symm (liesonleft_ne_pts h).2.symm).IsPos := sorry
 
-lemma liesonright_ne_pts {A B C : P} (hne : B ≠ A) (h : C LiesOnRight (DLIN A B hne)) : (C ≠ A) ∧ (C ≠ B) := sorry
+lemma liesonright_ne_pts {A B C : P} [hne : PtNe B A] (h : C LiesOnRight (DLIN A B)) : (C ≠ A) ∧ (C ≠ B) := sorry
 
-theorem liesonright_angle_isneg {A B C : P} (hne : B ≠ A) (h : C LiesOnRight (DLIN A B hne)) : (∠ A C B (liesonright_ne_pts hne h).1.symm (liesonright_ne_pts hne h).2.symm).IsNeg := sorry
+theorem liesonright_angle_isneg {A B C : P} [hne : PtNe B A] (h : C LiesOnRight (DLIN A B)) : (∠ A C B (liesonright_ne_pts h).1.symm (liesonright_ne_pts h).2.symm).IsNeg := sorry
 
 theorem liesonleft_iff_liesonright_reverse {A : P} {l : DirLine P} : A LiesOnLeft l ↔ A LiesOnRight l.reverse := sorry
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Basic.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Basic.lean
@@ -53,11 +53,11 @@ def point₂ : P := tr_nd.1.2
 @[pp_dot]
 def point₃ : P := tr_nd.1.3
 
-def nontriv₁ : tr_nd.point₃ ≠ tr_nd.point₂ := (ne_of_not_colinear tr_nd.2).1
+instance nontriv₁ : PtNe tr_nd.point₃ tr_nd.point₂ := ⟨(ne_of_not_colinear tr_nd.2).1⟩
 
-def nontriv₂ : tr_nd.point₁ ≠ tr_nd.point₃ := (ne_of_not_colinear tr_nd.2).2.1
+instance nontriv₂ : PtNe tr_nd.point₁ tr_nd.point₃ := ⟨(ne_of_not_colinear tr_nd.2).2.1⟩
 
-def nontriv₃ : tr_nd.point₂ ≠ tr_nd.point₁ := (ne_of_not_colinear tr_nd.2).2.2
+instance nontriv₃ : PtNe tr_nd.point₂ tr_nd.point₁ := ⟨(ne_of_not_colinear tr_nd.2).2.2⟩
 
 @[pp_dot]
 def edge₁ : Seg P := tr_nd.1.edge₁
@@ -69,29 +69,29 @@ def edge₂ : Seg P := tr_nd.1.edge₂
 def edge₃ : Seg P := tr_nd.1.edge₃
 
 @[pp_dot]
-def edge_nd₁ : SegND P := ⟨tr_nd.1.edge₁, tr_nd.nontriv₁⟩
+def edge_nd₁ : SegND P := ⟨tr_nd.1.edge₁, tr_nd.nontriv₁.out⟩
 
 @[pp_dot]
-def edge_nd₂ : SegND P := ⟨tr_nd.1.edge₂, tr_nd.nontriv₂⟩
+def edge_nd₂ : SegND P := ⟨tr_nd.1.edge₂, tr_nd.nontriv₂.out⟩
 
 @[pp_dot]
-def edge_nd₃ : SegND P := ⟨tr_nd.1.edge₃, tr_nd.nontriv₃⟩
+def edge_nd₃ : SegND P := ⟨tr_nd.1.edge₃, tr_nd.nontriv₃.out⟩
 
 @[pp_dot]
 def area : ℝ := tr_nd.1.area
 
 /- Only nondegenerate triangles can talk about orientation -/
 @[pp_dot]
-def is_cclock : Prop := tr_nd.1.3 LiesOnLeft (Ray.mk_pt_pt tr_nd.1.1 tr_nd.1.2 (tr_nd.nontriv₃))
+def is_cclock : Prop := tr_nd.1.3 LiesOnLeft (Ray.mk_pt_pt tr_nd.1.1 tr_nd.1.2 (tr_nd.nontriv₃.out))
 
 @[pp_dot]
-def angle₁ : Angle P := Angle.mk_pt_pt_pt _ _ _ (tr_nd.nontriv₃) (tr_nd.nontriv₂).symm
+def angle₁ : Angle P := ANG tr_nd.point₂ tr_nd.point₁ tr_nd.point₃
 
 @[pp_dot]
-def angle₂ : Angle P := Angle.mk_pt_pt_pt _ _ _ (tr_nd.nontriv₁) (tr_nd.nontriv₃).symm
+def angle₂ : Angle P := ANG tr_nd.point₃ tr_nd.point₂ tr_nd.point₁
 
 @[pp_dot]
-def angle₃ : Angle P := Angle.mk_pt_pt_pt _ _ _ (tr_nd.nontriv₂) (tr_nd.nontriv₁).symm
+def angle₃ : Angle P := ANG tr_nd.point₁ tr_nd.point₃ tr_nd.point₂
 
 end TriangleND
 
@@ -105,7 +105,7 @@ protected def IsInt (A : P) (tr : Triangle P) : Prop := by
   -- why not using ¬ tr.IsND?
   · exact False
   · let tr_nd : TriangleND P := ⟨tr, h⟩
-    exact (if tr_nd.is_cclock then A LiesOnLeft SegND.toRay ⟨tr.edge₁, tr_nd.nontriv₁⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr.edge₂, tr_nd.nontriv₂⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr.edge₃, tr_nd.nontriv₃⟩ else A LiesOnRight SegND.toRay ⟨tr.edge₁, tr_nd.nontriv₁⟩ ∧ A LiesOnRight SegND.toRay ⟨tr.edge₂, tr_nd.nontriv₂⟩ ∧ A LiesOnRight SegND.toRay ⟨tr.edge₃, tr_nd.nontriv₃⟩)
+    exact (if tr_nd.is_cclock then A LiesOnLeft SegND.toRay ⟨tr.edge₁, tr_nd.nontriv₁.out⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr.edge₂, tr_nd.nontriv₂.out⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr.edge₃, tr_nd.nontriv₃.out⟩ else A LiesOnRight SegND.toRay ⟨tr.edge₁, tr_nd.nontriv₁.out⟩ ∧ A LiesOnRight SegND.toRay ⟨tr.edge₂, tr_nd.nontriv₂.out⟩ ∧ A LiesOnRight SegND.toRay ⟨tr.edge₃, tr_nd.nontriv₃.out⟩)
 
 protected def IsOn (A : P) (tr : Triangle P) : Prop := Triangle.IsInt A tr ∨ A LiesOn tr.edge₁ ∨ A LiesOn tr.edge₂ ∨ A LiesOn tr.edge₃
 
@@ -128,7 +128,7 @@ end Triangle
 namespace TriangleND
 
 protected def IsInt (A : P) (tr_nd : TriangleND P) : Prop := by
-  exact (if tr_nd.is_cclock then A LiesOnLeft SegND.toRay ⟨tr_nd.edge₁, tr_nd.nontriv₁⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr_nd.edge₂, tr_nd.nontriv₂⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr_nd.edge₃, tr_nd.nontriv₃⟩ else A LiesOnRight SegND.toRay ⟨tr_nd.edge₁, tr_nd.nontriv₁⟩ ∧ A LiesOnRight SegND.toRay ⟨tr_nd.edge₂, tr_nd.nontriv₂⟩ ∧ A LiesOnRight SegND.toRay ⟨tr_nd.edge₃, tr_nd.nontriv₃⟩)
+  exact (if tr_nd.is_cclock then A LiesOnLeft SegND.toRay ⟨tr_nd.edge₁, tr_nd.nontriv₁.out⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr_nd.edge₂, tr_nd.nontriv₂.out⟩ ∧ A LiesOnLeft SegND.toRay ⟨tr_nd.edge₃, tr_nd.nontriv₃.out⟩ else A LiesOnRight SegND.toRay ⟨tr_nd.edge₁, tr_nd.nontriv₁.out⟩ ∧ A LiesOnRight SegND.toRay ⟨tr_nd.edge₂, tr_nd.nontriv₂.out⟩ ∧ A LiesOnRight SegND.toRay ⟨tr_nd.edge₃, tr_nd.nontriv₃.out⟩)
 
 protected def IsOn (A : P) (tr_nd : TriangleND P) : Prop := TriangleND.IsInt A tr_nd ∨ A LiesOn tr_nd.edge₁ ∨ A LiesOn tr_nd.edge₂ ∨ A LiesOn tr_nd.edge₃
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Basic_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Basic_trash.lean
@@ -23,7 +23,7 @@ theorem edge_toLine_not_para_of_not_colinear {A B C : P} (h : ¬ colinear A B C)
     exact (SEG_nd B C (ne_of_not_colinear h).1).source_lies_on_toLine
     exact h1
   have a_lies_on_ab : A LiesOn (LIN A B (ne_of_not_colinear h).2.2) := (SEG_nd A B (ne_of_not_colinear h).2.2).source_lies_on_toLine
-  have a_not_lies_on_bc := (Line.lies_on_line_of_pt_pt_iff_colinear (ne_of_not_colinear h).1 A).mp.mt (flip_colinear_snd_trd.mt (flip_colinear_fst_snd.mt h))
+  have a_not_lies_on_bc := (Line.lies_on_line_of_pt_pt_iff_colinear (_h := ⟨(ne_of_not_colinear h).1⟩) A).mp.mt (flip_colinear_snd_trd.mt (flip_colinear_fst_snd.mt h))
   simp only[← eq1] at a_not_lies_on_bc
   apply a_not_lies_on_bc
   exact a_lies_on_ab
@@ -35,7 +35,7 @@ theorem edge_toLine_not_para_of_not_colinear {A B C : P} (h : ¬ colinear A B C)
     exact (SEG_nd C A (ne_of_not_colinear h).2.1).source_lies_on_toLine
     exact h2
   have b_lies_on_bc : B LiesOn (LIN B C (ne_of_not_colinear h).1) := (SEG_nd B C (ne_of_not_colinear h).1).source_lies_on_toLine
-  have b_not_lies_on_ca := (Line.lies_on_line_of_pt_pt_iff_colinear (ne_of_not_colinear h).2.1 B).mp.mt (flip_colinear_fst_snd.mt (flip_colinear_snd_trd.mt h))
+  have b_not_lies_on_ca := (Line.lies_on_line_of_pt_pt_iff_colinear (_h := ⟨(ne_of_not_colinear h).2.1⟩) B).mp.mt (flip_colinear_fst_snd.mt (flip_colinear_snd_trd.mt h))
   simp only[← eq2] at b_not_lies_on_ca
   apply b_not_lies_on_ca
   exact b_lies_on_bc
@@ -46,7 +46,7 @@ theorem edge_toLine_not_para_of_not_colinear {A B C : P} (h : ¬ colinear A B C)
     exact (SEG_nd A B (ne_of_not_colinear h).2.2).source_lies_on_toLine
     exact h3
   have c_lies_on_ca : C LiesOn (LIN C A (ne_of_not_colinear h).2.1) := (SEG_nd C A (ne_of_not_colinear h).2.1).source_lies_on_toLine
-  have c_not_lies_on_ab := (Line.lies_on_line_of_pt_pt_iff_colinear (ne_of_not_colinear h).2.2 C).mp.mt h
+  have c_not_lies_on_ab := (Line.lies_on_line_of_pt_pt_iff_colinear (_h := ⟨(ne_of_not_colinear h).2.2⟩) C).mp.mt h
   simp only[← eq3] at c_not_lies_on_ab
   apply c_not_lies_on_ab
   exact c_lies_on_ca

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
@@ -381,13 +381,13 @@ theorem third_point_same_of_two_point_same (h : tr_nd₁.IsCongr tr_nd₂) (p₁
     simp only [<-p₂, <-p₁] ; rfl
     exact h.5
   have l₁ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₁.end_ray.toLine :=
-    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₁.nontriv₂.symm)
+    .inl Ray.snd_pt_lies_on_mk_pt_pt
   have l₂ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₂.start_ray.toLine :=
-    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₁.nontriv₁)
+    .inl Ray.snd_pt_lies_on_mk_pt_pt
   have l₃ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₁.end_ray.toLine :=
-    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₂.nontriv₂.symm)
+    .inl Ray.snd_pt_lies_on_mk_pt_pt
   have l₄ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₂.start_ray.toLine :=
-    .inl (Ray.snd_pt_lies_on_mk_pt_pt tr_nd₂.nontriv₁)
+    .inl Ray.snd_pt_lies_on_mk_pt_pt
   have np₁ : ¬ tr_nd₁.angle₁.end_ray.toLine ∥ tr_nd₁.angle₂.start_ray.toLine := by
     by_contra pl
     have l₅ : tr_nd₁.point₁ LiesOn tr_nd₁.angle₁.end_ray.toLine := by

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Trigonometric.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Trigonometric.lean
@@ -12,9 +12,9 @@ namespace Triangle
 
 -- Cosine rule : for a nontrivial triangle ABC, BC^2 = AB^2 + AC^2 - 2 * AB * AC * cos ANG BAC.
 
-theorem cosine_rule' (A B C : P) (hab : B ≠ A) (hac : C ≠ A) :
-    2 * (‖VEC_nd A B hab‖ * ‖VEC_nd A C hac‖ *
-      cos (VecND.angle (VEC_nd A B hab) (VEC_nd A C hac))) =
+theorem cosine_rule' (A B C : P) [hab : PtNe B A] [hac : PtNe C A] :
+    2 * (‖VEC_nd A B‖ * ‖VEC_nd A C‖ *
+      cos (VecND.angle (VEC_nd A B) (VEC_nd A C))) =
       Seg.length (SEG A B) ^ 2 + Seg.length (SEG A C) ^ 2 - Seg.length (SEG B C) ^ 2 := by
   rw [VecND.norm_mul_cos, length_sq_eq_inner_toVec_toVec,
     length_sq_eq_inner_toVec_toVec, length_sq_eq_inner_toVec_toVec, seg_toVec_eq_vec,
@@ -28,8 +28,8 @@ theorem cosine_rule (tr_nd : TriangleND P) : 2 * (tr_nd.edge₃.length * tr_nd.e
   let A := tr_nd.1.point₁
   let B := tr_nd.1.point₂
   let C := tr_nd.1.point₃
-  let h₃ := cosine_rule' A B C (tr_nd.nontriv₃) (Ne.symm tr_nd.nontriv₂)
-  have h₄ : ‖VEC_nd A C (Ne.symm tr_nd.nontriv₂)‖ = ‖VEC_nd C A (tr_nd.nontriv₂)‖
+  let h₃ := @cosine_rule' _ _ A B C tr_nd.nontriv₃ tr_nd.nontriv₂.symm
+  have h₄ : ‖VEC_nd A C tr_nd.nontriv₂.out.symm‖ = ‖VEC_nd C A tr_nd.nontriv₂.out‖
   · simp_rw [VecND.mkPtPt, ← neg_vec A C]
     simp
   have h₅ : Seg.length (SEG A C) = Seg.length (SEG C A)

--- a/EuclideanGeometry/Foundation/Construction/ComputationTool/Ceva.lean
+++ b/EuclideanGeometry/Foundation/Construction/ComputationTool/Ceva.lean
@@ -18,31 +18,33 @@ class CevaCfgClass (P : outParam <| Type*) [outParam <| EuclideanPlane P] where
   bcd_nd : ¬colinear B C D
   cad_nd : ¬colinear C A D
 
-  a_ne_b : A ≠ B := (ne_of_not_colinear abd_nd).2.2.symm
-  b_ne_c : B ≠ C := (ne_of_not_colinear bcd_nd).2.2.symm
-  c_ne_a : C ≠ A := (ne_of_not_colinear cad_nd).2.2.symm
-  d_ne_a : D ≠ A := (ne_of_not_colinear abd_nd).2.1.symm
-  d_ne_b : D ≠ B := (ne_of_not_colinear bcd_nd).2.1.symm
-  d_ne_c : D ≠ C := (ne_of_not_colinear cad_nd).2.1.symm
+  a_ne_b : PtNe A B := ⟨(ne_of_not_colinear abd_nd).2.2.symm⟩
+  b_ne_c : PtNe B C := ⟨(ne_of_not_colinear bcd_nd).2.2.symm⟩
+  c_ne_a : PtNe C A := ⟨(ne_of_not_colinear cad_nd).2.2.symm⟩
+  d_ne_a : PtNe D A := ⟨(ne_of_not_colinear abd_nd).2.1.symm⟩
+  d_ne_b : PtNe D B := ⟨(ne_of_not_colinear bcd_nd).2.1.symm⟩
+  d_ne_c : PtNe D C := ⟨(ne_of_not_colinear cad_nd).2.1.symm⟩
 
   --$BA$ is not parallel to $CD$
-  ba_npara_cd : ¬ LIN B A a_ne_b ∥ LIN C D d_ne_c
+  (ba_npara_cd : ¬ LIN B A ∥ LIN C D)
   --$CB$ is not parallel to $AD$
-  cb_npara_ad : ¬ LIN C B b_ne_c ∥ LIN A D d_ne_a
+  (cb_npara_ad : ¬ LIN C B ∥ LIN A D)
   --$AC$ is not parallel to $BD$
-  ac_npara_bd : ¬ LIN A C c_ne_a ∥ LIN B D d_ne_b
+  (ac_npara_bd : ¬ LIN A C ∥ LIN B D)
   --Let $E$ be the intersection of $CB$ and $AD$
   E : P
-  e_def : E = Line.inx (LIN C B b_ne_c) (LIN A D d_ne_a) cb_npara_ad
+  e_def : E = Line.inx (LIN C B) (LIN A D) cb_npara_ad
   --Let $F$ be the intersection of $AC$ and $BD$
   F : P
-  f_def : F = Line.inx (LIN A C c_ne_a) (LIN B D d_ne_b) ac_npara_bd
+  f_def : F = Line.inx (LIN A C) (LIN B D) ac_npara_bd
   --Let $G$ be the intersection of $BA$ and $CD$
   G : P
-  g_def : G = Line.inx (LIN B A a_ne_b) (LIN C D d_ne_c) ba_npara_cd
+  g_def : G = Line.inx (LIN B A) (LIN C D) ba_npara_cd
 
 namespace CevaCfgClass
 variable {P : Type*} [EuclideanPlane P] [cfg : CevaCfgClass P]
+
+attribute [instance] a_ne_b b_ne_c c_ne_a d_ne_a d_ne_b d_ne_c
 
 --$D,C,A$ are not colinear
 lemma ncolin_dca : ¬ colinear D C A := by
@@ -51,20 +53,20 @@ lemma ncolin_dca : ¬ colinear D C A := by
 
 --$E,B,C$ are colinear
 lemma colin_ebc : colinear E B C := by
-  have h : E LiesOn LIN C B (_ : B ≠ C) := by
+  have h : E LiesOn LIN C B := by
     rw [e_def]
     apply Line.inx_lies_on_fst
-  exact flip_colinear_fst_trd (Line.pt_pt_linear (_ : B ≠ C) h)
+  exact flip_colinear_fst_trd (Line.pt_pt_linear h)
 
 --$E,D,A$ are colinear
 lemma colin_eda : colinear E D A := by
-  have h : E LiesOn LIN A D (_ : D ≠ A) := by
+  have h : E LiesOn LIN A D := by
     rw [e_def]
     apply Line.inx_lies_on_snd
-  exact flip_colinear_fst_trd (Line.pt_pt_linear (_ : D ≠ A) h)
+  exact flip_colinear_fst_trd (Line.pt_pt_linear h)
 
 --$C\ne E$
-lemma c_ne_e : C ≠ E := by
+instance c_ne_e : PtNe C E := Fact.mk <| by
   have h : colinear E D A := colin_eda
   intro k
   rw [←k] at h
@@ -72,7 +74,7 @@ lemma c_ne_e : C ≠ E := by
 
 --$EB/EC=S_{\trian}DBA/S_{\trian}DCA$
 lemma dratio_ebc_eq_wedge_div_wedge : divratio E B C = (wedge D B A) / (wedge D C A) :=
-  ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear E B C D A colin_ebc c_ne_e colin_eda ncolin_dca
+  ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear E B C D A colin_ebc colin_eda ncolin_dca
 
 --$D,A,B$ are not colinear
 lemma ncolin_dab : ¬ colinear D A B := by
@@ -81,20 +83,20 @@ lemma ncolin_dab : ¬ colinear D A B := by
 
 --$F,C,A$ are colinear
 lemma colin_fca : colinear F C A := by
-  have h : F LiesOn LIN A C _ := by
+  have h : F LiesOn LIN A C := by
     rw [f_def]
     apply Line.inx_lies_on_fst
-  exact flip_colinear_fst_trd (Line.pt_pt_linear _ h)
+  exact flip_colinear_fst_trd (Line.pt_pt_linear h)
 
 --$F,D,B$ are colinear
 lemma colin_fdb : colinear F D B := by
-  have h : F LiesOn LIN B D _ := by
+  have h : F LiesOn LIN B D := by
     rw [f_def]
     apply Line.inx_lies_on_snd
-  exact flip_colinear_fst_trd (Line.pt_pt_linear _ h)
+  exact flip_colinear_fst_trd (Line.pt_pt_linear h)
 
 --$A\ne F$
-lemma a_ne_f : A ≠ F := by
+instance a_ne_f : PtNe A F := Fact.mk <| by
   have h : colinear F D B := colin_fdb
   intro k
   rw [←k] at h
@@ -102,7 +104,7 @@ lemma a_ne_f : A ≠ F := by
 
 --$FC/FA=S_{\trian}DCB/S_{\trian}DAB$
 lemma dratio_fca_eq_wedge_div_wedge : divratio F C A = (wedge D C B) / (wedge D A B) :=
-  ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear F C A D B colin_fca a_ne_f colin_fdb ncolin_dab
+  ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear F C A D B colin_fca colin_fdb ncolin_dab
 
 --$D,B,C$ are not colinear
 lemma ncolin_dbc : ¬ colinear D B C := by
@@ -114,24 +116,24 @@ lemma colin_gab : colinear G A B := by
   have h : G LiesOn LIN B A _ := by
     rw [g_def]
     apply Line.inx_lies_on_fst
-  exact flip_colinear_fst_trd (Line.pt_pt_linear _ h)
+  exact flip_colinear_fst_trd (Line.pt_pt_linear h)
 
 --$G,D,C$ are colinear
 lemma colin_gdc : colinear G D C := by
   have h : G LiesOn LIN C D _ := by
     rw [g_def]
     apply Line.inx_lies_on_snd
-  exact flip_colinear_fst_trd (Line.pt_pt_linear _ h)
+  exact flip_colinear_fst_trd (Line.pt_pt_linear h)
 
 --$A\ne F$
-lemma b_ne_g : B ≠ G := by
+instance b_ne_g : PtNe B G := Fact.mk <| by
   have h : colinear G D C := colin_gdc
   intro k
   rw [←k] at h
   exact ncolin_dbc (flip_colinear_fst_snd h)
 
 --$GA/GB=S_{\trian}DAC/S_{\trian}DBC$
-lemma dratio_gab_eq_wedge_div_wedge : divratio G A B = (wedge D A C) / (wedge D B C) := ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear G A B D C colin_gab b_ne_g colin_gdc ncolin_dbc
+lemma dratio_gab_eq_wedge_div_wedge : divratio G A B = (wedge D A C) / (wedge D B C) := ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear G A B D C colin_gab colin_gdc ncolin_dbc
 
 lemma wedge_div_wedge_mul_eq_minus_one : (wedge D B A)/(wedge D C A) * ((wedge D C B)/(wedge D A B)) * ((wedge D A C)/(wedge D B C)) = -1 := by
   rw [wedge132 D A B, wedge132 D B C, wedge132 D C A]

--- a/EuclideanGeometry/Foundation/Construction/ComputationTool/Oarea_method.lean
+++ b/EuclideanGeometry/Foundation/Construction/ComputationTool/Oarea_method.lean
@@ -22,12 +22,12 @@ theorem wedge_eq_wedge_add_wedge_of_colinear (A B C D : P) (colin : colinear A B
   rw[← wedge231 D B C, ← wedge_add_wedge_eq_wedge_add_wedge,← wedge231 C D A, (colinear_iff_wedge_eq_zero A B C).mp colin]
   field_simp
 
-theorem wedge_eq_divratio_mul_wedge_of_colinear (A B C D : P) (colin : colinear A B C) (cnea : C ≠ A) : wedge A B D = (divratio A B C) * wedge A C D := by
+theorem wedge_eq_divratio_mul_wedge_of_colinear (A B C D : P) (colin : colinear A B C) [cnea : PtNe C A] : wedge A B D = (divratio A B C) * wedge A C D := by
   unfold wedge
-  rw [vec_eq_vec_smul_ratio A B C colin cnea]
+  rw [vec_eq_vec_smul_ratio A B C colin]
   simp only [map_smul, LinearMap.smul_apply, smul_eq_mul]
 
-theorem odist_eq_divratio_mul_odist (A B C : P) (dl : DirLine P) (colin : colinear A B C) (cnea : C ≠ A) (aisondl : A LiesOn dl) : odist B dl = (divratio A B C) * odist C dl := by
+theorem odist_eq_divratio_mul_odist (A B C : P) (dl : DirLine P) (colin : colinear A B C) [cnea : PtNe C A] (aisondl : A LiesOn dl) : odist B dl = (divratio A B C) * odist C dl := by
   have h0 : odist' B (Ray.mk_pt_dirline A dl aisondl)= odist B (Ray.mk_pt_dirline A dl aisondl).toDirLine := rfl
   have h1 : odist B dl = odist' B (Ray.mk_pt_dirline A dl aisondl) := by
     rw[h0,ray_of_pt_dirline_toDirLine_eq_dirline A dl aisondl]
@@ -37,15 +37,15 @@ theorem odist_eq_divratio_mul_odist (A B C : P) (dl : DirLine P) (colin : coline
   rw [h1, h3]
   unfold odist'
   have h4 : (Ray.mk_pt_dirline A dl aisondl).source = A := rfl
-  rw [h4, vec_eq_vec_smul_ratio A B C colin cnea]
+  rw [h4, vec_eq_vec_smul_ratio A B C colin]
   simp only [map_smul, smul_eq_mul]
 
-theorem  wedge_eq_divratio_mul_wedge_of_colinear_colinear (A B C D E : P) (colin : colinear A B C) (cnea : C ≠ A) (colin' : colinear A D E) : wedge D B E = (divratio A B C) * wedge D C E := by
-  rw[← wedge231 D B E, wedge_eq_wedge_add_wedge_of_colinear E A D B (perm_colinear_trd_fst_snd colin'), ← wedge231 D C E, wedge_eq_wedge_add_wedge_of_colinear E A D C (perm_colinear_trd_fst_snd colin'), wedge213 A B D, wedge231 A B E, wedge213 A C D, wedge231 A C E,wedge_eq_divratio_mul_wedge_of_colinear A B C D colin cnea,wedge_eq_divratio_mul_wedge_of_colinear A B C E colin cnea]
+theorem  wedge_eq_divratio_mul_wedge_of_colinear_colinear (A B C D E : P) (colin : colinear A B C) [cnea : PtNe C A] (colin' : colinear A D E) : wedge D B E = (divratio A B C) * wedge D C E := by
+  rw[← wedge231 D B E, wedge_eq_wedge_add_wedge_of_colinear E A D B (perm_colinear_trd_fst_snd colin'), ← wedge231 D C E, wedge_eq_wedge_add_wedge_of_colinear E A D C (perm_colinear_trd_fst_snd colin'), wedge213 A B D, wedge231 A B E, wedge213 A C D, wedge231 A C E,wedge_eq_divratio_mul_wedge_of_colinear A B C D colin,wedge_eq_divratio_mul_wedge_of_colinear A B C E colin]
   ring
 
-theorem ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear (A B C D E : P) (colin : colinear A B C) (cnea : C ≠ A) (colin' : colinear A D E) (ncolin : ¬ colinear D C E) : divratio A B C = (wedge D B E) / (wedge D C E) := by
-  rw [wedge_eq_divratio_mul_wedge_of_colinear_colinear A B C D E colin cnea colin']
+theorem ratio_eq_wedge_div_wedge_of_colinear_colinear_notcoliear (A B C D E : P) (colin : colinear A B C) [cnea : PtNe C A] (colin' : colinear A D E) (ncolin : ¬ colinear D C E) : divratio A B C = (wedge D B E) / (wedge D C E) := by
+  rw [wedge_eq_divratio_mul_wedge_of_colinear_colinear A B C D E colin colin']
   have h0 : ¬ wedge D C E = 0 := by
     rw[(colinear_iff_wedge_eq_zero D C E).symm]
     exact ncolin

--- a/EuclideanGeometry/Foundation/Construction/Polygon/Parallelogram.lean
+++ b/EuclideanGeometry/Foundation/Construction/Polygon/Parallelogram.lean
@@ -78,7 +78,7 @@ theorem is_prg_nd_of_para_para (h₁ : qdr_cvx.edge_nd₁₂ ∥ qdr_cvx.edge_nd
   exact h₂
 
 /-- Given four points ABCD and Quadrilateral ABCD IsConvex, AB ∥ CD and AD ∥ BC, Quadrilateral ABCD is a Parallelogram_nd. -/
-theorem is_prg_nd_of_para_para_variant (h₁ : (SEG_nd A B (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h))) ∥ (SEG_nd C D (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)))) (h₂ : (SEG_nd A D (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h))) ∥ (SEG_nd B C (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)))) : QDR A B C D IsPRG_nd := by
+theorem is_prg_nd_of_para_para_variant (h₁ : (SEG_nd A B (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h)).out) ∥ (SEG_nd C D (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)).out)) (h₂ : (SEG_nd A D (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h)).out) ∥ (SEG_nd B C (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)).out)) : QDR A B C D IsPRG_nd := by
   unfold Quadrilateral.IsParallelogram_nd
   rw [dif_pos h]
   unfold Quadrilateral_cvx.IsParallelogram_nd
@@ -93,22 +93,22 @@ theorem is_prg_nd_of_eq_length_eq_length (h₁ : (qdr_cvx.edge_nd₁₂).1.lengt
   unfold Quadrilateral_cvx.edge_nd₃₄ at h₁
   unfold Quadrilateral_cvx.edge_nd₁₄ at h₂
   unfold Quadrilateral_cvx.edge_nd₂₃ at h₂
-  have prep₁: (qdr_cvx.triangle₁).1.edge₁ = SEG_nd qdr_cvx.point₁ qdr_cvx.point₂ qdr_cvx.nd₁₂ := rfl
-  have prep₂: (qdr_cvx.triangle₃).1.edge₁ = SEG_nd qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.nd₃₄ := rfl
+  have prep₁: (qdr_cvx.triangle₁).1.edge₁ = SEG_nd qdr_cvx.point₁ qdr_cvx.point₂ := rfl
+  have prep₂: (qdr_cvx.triangle₃).1.edge₁ = SEG_nd qdr_cvx.point₃ qdr_cvx.point₄ := rfl
   have t₁: (qdr_cvx.triangle₁).1.edge₁.length = (qdr_cvx.triangle₃).1.edge₁.length := by
     rw [prep₁, prep₂]
     exact h₁
-  have prep₃: (qdr_cvx.triangle₁).1.edge₂.length = (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ qdr_cvx.nd₂₄).1.length := rfl
-  have prep₄: (qdr_cvx.triangle₃).1.edge₂.length = (SEG_nd qdr_cvx.point₄ qdr_cvx.point₂ qdr_cvx.nd₂₄.symm).1.length := rfl
-  have prep₅: (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ qdr_cvx.nd₂₄).1.length = (SEG_nd qdr_cvx.point₄ qdr_cvx.point₂ qdr_cvx.nd₂₄.symm).1.length := by
+  have prep₃: (qdr_cvx.triangle₁).1.edge₂.length = (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄).1.length := rfl
+  have prep₄: (qdr_cvx.triangle₃).1.edge₂.length = (SEG_nd qdr_cvx.point₄ qdr_cvx.point₂).1.length := rfl
+  have prep₅: (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄).1.length = (SEG_nd qdr_cvx.point₄ qdr_cvx.point₂).1.length := by
     apply SegND.length_of_rev_eq_length.symm
-  have prep₈: (SEG_nd qdr_cvx.point₁ qdr_cvx.point₄ qdr_cvx.nd₁₄).1.length = (SEG_nd qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.nd₁₄.symm).1.length := by
+  have prep₈: (SEG_nd qdr_cvx.point₁ qdr_cvx.point₄).1.length = (SEG_nd qdr_cvx.point₄ qdr_cvx.point₁).1.length := by
     apply SegND.length_of_rev_eq_length.symm
   have t₂: (qdr_cvx.triangle₁).1.edge₂.length = (qdr_cvx.triangle₃).1.edge₂.length := by
     rw [prep₃, prep₄]
     exact prep₅
-  have prep₆: (qdr_cvx.triangle₁).1.edge₃ = SEG_nd qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.nd₁₄.symm := rfl
-  have prep₇: (qdr_cvx.triangle₃).1.edge₃ = SEG_nd qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.nd₂₃ := rfl
+  have prep₆: (qdr_cvx.triangle₁).1.edge₃ = SEG_nd qdr_cvx.point₄ qdr_cvx.point₁ := rfl
+  have prep₇: (qdr_cvx.triangle₃).1.edge₃ = SEG_nd qdr_cvx.point₂ qdr_cvx.point₃ := rfl
   have t₃: (qdr_cvx.triangle₁).1.edge₃.length = (qdr_cvx.triangle₃).1.edge₃.length := by
     rw [prep₆, prep₇, prep₈.symm]
     exact h₂
@@ -200,10 +200,10 @@ theorem is_prg_nd_of_para_eq_length (h₁ : qdr_cvx.edge_nd₁₂ ∥ qdr_cvx.ed
   have diag_ng_para: ¬ qdr_cvx.diag_nd₁₃.toProj = qdr_cvx.diag_nd₂₄.toProj := qdr_cvx.diag_not_para
   rcases h with case_not_convex | case_convex
   -- Case that is not convex, goal is prove contra
-  have angle₁_eq_angle₄: (ANG qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.nd₃₄.symm qdr_cvx.nd₁₄.symm).value = (ANG qdr_cvx.point₂ qdr_cvx.point₁ qdr_cvx.point₄ qdr_cvx.nd₁₂ qdr_cvx.nd₁₄).value := by
+  have angle₁_eq_angle₄: (ANG qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁).value = (ANG qdr_cvx.point₂ qdr_cvx.point₁ qdr_cvx.point₄).value := by
     apply ang_eq_ang_of_toDir_rev_toDir
-    have ray₁₂_toDir_eq_SegND₁₂_toDir: qdr_cvx.edge_nd₁₂.toDir = (ANG qdr_cvx.point₂ qdr_cvx.point₁ qdr_cvx.point₄ qdr_cvx.nd₁₂ qdr_cvx.nd₁₄).start_ray.toDir := by rfl
-    have ray₄₃_toDir_eq_SegND₃₄_rev_toDir: qdr_cvx.edge_nd₃₄.reverse.toDir = (ANG qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.nd₃₄.symm qdr_cvx.nd₁₄.symm).start_ray.toDir := by rfl
+    have ray₁₂_toDir_eq_SegND₁₂_toDir: qdr_cvx.edge_nd₁₂.toDir = (ANG qdr_cvx.point₂ qdr_cvx.point₁ qdr_cvx.point₄).start_ray.toDir := by rfl
+    have ray₄₃_toDir_eq_SegND₃₄_rev_toDir: qdr_cvx.edge_nd₃₄.reverse.toDir = (ANG qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁).start_ray.toDir := by rfl
     have SegND₄₃_toDir_neg_SegND₃₄_rev_toDir: qdr_cvx.edge_nd₃₄.reverse.toDir = - qdr_cvx.edge_nd₃₄.toDir := by apply SegND.toDir_of_rev_eq_neg_toDir
     rw [ray₁₂_toDir_eq_SegND₁₂_toDir.symm, ray₄₃_toDir_eq_SegND₃₄_rev_toDir.symm, SegND₄₃_toDir_neg_SegND₃₄_rev_toDir, case_not_convex]
     exact qdr_cvx.edge_nd₁₄.toDir_of_rev_eq_neg_toDir
@@ -290,7 +290,7 @@ theorem is_prg_nd_of_para_eq_length (h₁ : qdr_cvx.edge_nd₁₂ ∥ qdr_cvx.ed
   -- Done!
 
 /-- Given four points ABCD and Quadrilateral ABCD IsConvex, and AB ∥ CD and AB = CD, Quadrilateral ABCD is a Parallelogram_nd. -/
-theorem is_prg_nd_of_para_eq_length_variant (h₁ : (SEG_nd A B (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h))) ∥ (SEG_nd C D (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)))) (h₂ : (SEG A B).length = (SEG C D).length) : QDR A B C D IsPRG_nd := by
+theorem is_prg_nd_of_para_eq_length_variant (h₁ : (SEG_nd A B (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h)).out) ∥ (SEG_nd C D (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)).out)) (h₂ : (SEG A B).length = (SEG C D).length) : QDR A B C D IsPRG_nd := by
   unfold Quadrilateral.IsParallelogram_nd
   by_cases j: QDR A B C D IsConvex
   simp only [j, dite_true]
@@ -336,7 +336,7 @@ theorem is_prg_nd_of_para_eq_length' (h₁ : qdr_cvx.edge_nd₁₄ ∥ qdr_cvx.e
   exact h₁
 
 /-- Given four points ABCD and Quadrilateral ABCD IsConvex, and AD ∥ BC and AD = BC, Quadrilateral ABCD is a Parallelogram_nd. -/
-theorem is_prg_nd_of_para_eq_length'_variant (h₁ : (SEG_nd A D (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h))) ∥ (SEG_nd B C (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)))) (h₂ : (SEG A D).length = (SEG B C).length) : QDR A B C D IsPRG_nd := by
+theorem is_prg_nd_of_para_eq_length'_variant (h₁ : (SEG_nd A D (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h)).out) ∥ (SEG_nd B C (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)).out)) (h₂ : (SEG A D).length = (SEG B C).length) : QDR A B C D IsPRG_nd := by
   unfold Quadrilateral.IsParallelogram_nd
   by_cases j: QDR A B C D IsConvex
   simp only [j, dite_true]
@@ -351,7 +351,7 @@ theorem is_prg_nd_of_eq_angle_value_eq_angle_value (h₁ : qdr_cvx.angle₁ = qd
   sorry
 
 /-- Given four points ABCD and Quadrilateral ABCD IsConvex, and ∠DAB = ∠BCD and ∠ABC = ∠CDA, Quadrilateral ABCD is a Parallelogram_nd. -/
-theorem is_prg_of_eq_angle_value_eq_angle_value_variant (h₁ : (ANG D A B (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h)) (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h))) = (ANG B C D (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)).symm (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)))) (h₂ : (ANG A B C (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h)).symm (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h))) = (ANG C D A (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)).symm (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h)).symm)) : QDR A B C D IsPRG_nd := by
+theorem is_prg_of_eq_angle_value_eq_angle_value_variant (h₁ : (ANG D A B (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h)).out (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h)).out) = (ANG B C D (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)).out.symm (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)).out)) (h₂ : (ANG A B C (Quadrilateral_cvx.nd₁₂ (Quadrilateral_cvx.mk_is_convex h)).out.symm (Quadrilateral_cvx.nd₂₃ (Quadrilateral_cvx.mk_is_convex h)).out) = (ANG C D A (Quadrilateral_cvx.nd₃₄ (Quadrilateral_cvx.mk_is_convex h)).out.symm (Quadrilateral_cvx.nd₁₄ (Quadrilateral_cvx.mk_is_convex h)).out.symm)) : QDR A B C D IsPRG_nd := by
   unfold Quadrilateral.IsParallelogram_nd
   by_cases j: QDR A B C D IsConvex
   simp only [j, dite_true]
@@ -466,42 +466,42 @@ theorem nd₂₄_of_is_prg_nd_variant (h : QDR A B C D IsPRG_nd) : D ≠ B := by
 /-- Given Quadrilateral qdr IsPRG_nd, qdr.point₂ ≠ qdr.point₁. -/
 theorem nd₁₂_of_is_prg_nd (h : qdr.IsParallelogram_nd) : qdr.point₂ ≠ qdr.point₁ := by
   have s : qdr.IsConvex:= is_convex_of_is_prg_nd qdr h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₂
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₂.out
 
 /-- Given four points ABCD and Quadrilateral ABCD IsPRG_nd, B ≠ A. -/
 theorem nd₁₂_of_is_prg_nd_variant (h : QDR A B C D IsPRG_nd) : B ≠ A := by
   have s : (QDR A B C D) IsConvex:= is_convex_of_is_prg_nd_variant h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₂
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₂.out
 
 /-- Given Quadrilateral qdr IsPRG_nd, qdr.point₃ ≠ qdr.point₂. -/
 theorem nd₂₃_of_is_prg_nd (h : qdr.IsParallelogram_nd) : qdr.point₃ ≠ qdr.point₂ := by
   have s : qdr.IsConvex:= is_convex_of_is_prg_nd qdr h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₂₃
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₂₃.out
 
 /-- Given four points ABCD and Quadrilateral ABCD IsPRG_nd, C ≠ B. -/
 theorem nd₂₃_of_is_prg_nd_variant (h : QDR A B C D IsPRG_nd) : C ≠ B := by
   have s : (QDR A B C D) IsConvex:= is_convex_of_is_prg_nd_variant h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₂₃
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₂₃.out
 
 /-- Given Quadrilateral qdr IsPRG_nd, qdr.point₄ ≠ qdr.point₃. -/
 theorem nd₃₄_of_is_prg_nd (h : qdr.IsParallelogram_nd) : qdr.point₄ ≠ qdr.point₃ := by
   have s : qdr.IsConvex:= is_convex_of_is_prg_nd qdr h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₃₄
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₃₄.out
 
 /-- Given four points ABCD and Quadrilateral ABCD IsPRG_nd, D ≠ C. -/
 theorem nd₃₄_of_is_prg_nd_variant (h : QDR A B C D IsPRG_nd) : D ≠ C := by
   have s : (QDR A B C D) IsConvex:= is_convex_of_is_prg_nd_variant h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₃₄
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₃₄.out
 
 /-- Given Quadrilateral qdr IsPRG_nd, qdr.point₄ ≠ qdr.point₁. -/
 theorem nd₁₄_of_is_prg_nd (h : qdr.IsParallelogram_nd) : qdr.point₄ ≠ qdr.point₁ := by
   have s : qdr.IsConvex:= is_convex_of_is_prg_nd qdr h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₄
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₄.out
 
 /-- Given four points ABCD and Quadrilateral ABCD IsPRG_nd, D ≠ A. -/
 theorem nd₁₄_of_is_prg_nd_variant (h : QDR A B C D IsPRG_nd) : D ≠ A := by
   have s : (QDR A B C D) IsConvex:= is_convex_of_is_prg_nd_variant h
-  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₄
+  exact (Quadrilateral_cvx.mk_is_convex s).nd₁₄.out
 
 /-- Given Quadrilateral qdr IsPRG_nd, the opposite sides are parallel namely (SEG_nd qdr.point₁ qdr.point₂ (nd₁₂_of_is_prg_abstract qdr h)) ∥ (SEG_nd qdr.point₃ qdr.point₄ (nd₃₄_of_is_prg_abstract qdr h)). -/
 theorem para_of_is_prg_nd (h : qdr.IsParallelogram_nd) : (SEG_nd qdr.point₁ qdr.point₂ (nd₁₂_of_is_prg_nd qdr h)) ∥ (SEG_nd qdr.point₃ qdr.point₄ (nd₃₄_of_is_prg_nd qdr h)):= by

--- a/EuclideanGeometry/Foundation/Construction/Polygon/Quadrilateral.lean
+++ b/EuclideanGeometry/Foundation/Construction/Polygon/Quadrilateral.lean
@@ -116,7 +116,7 @@ section property
 variable {P : Type _} [EuclideanPlane P] (qdr_cvx : Quadrilateral_cvx P)
 
 /-- Given a convex quadrilateral qdr_cvx, diagonal from the first point to the second point is not degenerate, i.e. the second point is not equal to the first point. -/
-theorem nd₁₃ : qdr_cvx.point₃ ≠ qdr_cvx.point₁ := by
+instance nd₁₃ : PtNe qdr_cvx.point₃ qdr_cvx.point₁ := Fact.mk <| by
   have h: qdr_cvx.IsConvex := convex _
   unfold Quadrilateral.IsConvex at h
   by_cases k: qdr_cvx.point₁ ≠ qdr_cvx.point₃ ∧ qdr_cvx.point₂ ≠ qdr_cvx.point₄
@@ -124,7 +124,7 @@ theorem nd₁₃ : qdr_cvx.point₃ ≠ qdr_cvx.point₁ := by
   simp only [k, dite_false] at h
 
 /-- Given a convex quadrilateral qdr_cvx, diagonal from the first point to the second point is not degenerate, i.e. the second point is not equal to the first point. -/
-theorem nd₂₄ : qdr_cvx.point₄ ≠ qdr_cvx.point₂ := by
+instance nd₂₄ : PtNe qdr_cvx.point₄ qdr_cvx.point₂ := Fact.mk <| by
   have h: qdr_cvx.IsConvex := convex _
   unfold Quadrilateral.IsConvex at h
   by_cases k: qdr_cvx.point₁ ≠ qdr_cvx.point₃ ∧ qdr_cvx.point₂ ≠ qdr_cvx.point₄
@@ -132,17 +132,16 @@ theorem nd₂₄ : qdr_cvx.point₄ ≠ qdr_cvx.point₂ := by
   simp only [k, dite_false] at h
 
 /-- The non-degenerate diagonal from the first point and third point of a convex quadrilateral -/
-def diag_nd₁₃ : SegND P := SEG_nd qdr_cvx.point₁ qdr_cvx.point₃ qdr_cvx.nd₁₃
+def diag_nd₁₃ : SegND P := SEG_nd qdr_cvx.point₁ qdr_cvx.point₃
 
 /-- The non-degenerate diagonal from the second point and fourth point of a convex quadrilateral -/
-def diag_nd₂₄ : SegND P := SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ qdr_cvx.nd₂₄
+def diag_nd₂₄ : SegND P := SEG_nd qdr_cvx.point₂ qdr_cvx.point₄
 
 /-- Two diagonals are not parallel to each other -/
 theorem diag_not_para : ¬ qdr_cvx.diag_nd₁₃ ∥ qdr_cvx.diag_nd₂₄ := by
-  have h: qdr_cvx.point₁ ≠ qdr_cvx.point₃ ∧ qdr_cvx.point₂ ≠ qdr_cvx.point₄ := ⟨qdr_cvx.nd₁₃.symm, qdr_cvx.nd₂₄.symm⟩
   have k: qdr_cvx.IsConvex := convex _
   unfold Quadrilateral.IsConvex at k
-  simp only [ne_eq, h, not_false_eq_true, and_self, dite_true] at k
+  simp only [ne_eq, not_false_eq_true, and_self, dite_true] at k
   by_contra q
   have r: qdr_cvx.diag_nd₂₄ ∥ qdr_cvx.diag_nd₁₃ := by exact q.symm
   rw [diag_nd₁₃, diag_nd₂₄] at r
@@ -155,31 +154,28 @@ def diag_inx : P := Line.inx qdr_cvx.diag_nd₁₃.toLine qdr_cvx.diag_nd₂₄.
 /-- The interior of two diagonals intersect at one point, i.e. the intersection point of the underlying lines of the diagonals lies in the interior of both diagonals. -/
 theorem diag_inx_lies_int : qdr_cvx.diag_inx LiesInt qdr_cvx.diag_nd₁₃.1 ∧ qdr_cvx.diag_inx LiesInt qdr_cvx.diag_nd₂₄.1
 := by
-  have h: qdr_cvx.point₁ ≠ qdr_cvx.point₃ ∧ qdr_cvx.point₂ ≠ qdr_cvx.point₄ := ⟨qdr_cvx.nd₁₃.symm, qdr_cvx.nd₂₄.symm⟩
   have k: qdr_cvx.IsConvex := convex _
   unfold Quadrilateral.IsConvex at k
-  simp only [ne_eq, h, not_false_eq_true, and_self, dite_true] at k
+  simp only [ne_eq, not_false_eq_true, and_self, dite_true] at k
   have g: ¬ qdr_cvx.diag_nd₂₄ ∥ qdr_cvx.diag_nd₁₃ := Ne.symm qdr_cvx.diag_not_para
   rw [diag_nd₁₃, diag_nd₂₄] at g
-  simp only [g, dite_true] at k
-  exact k
+  simpa only [g, dite_true, pt_ne] using k
 
 /-- Given a convex quadrilateral qdr_cvx ABCD, quadrilateral QDR BCDA is also convex. -/
 theorem permute_is_convex : (QDR qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁) IsConvex := by
   unfold Quadrilateral.IsConvex
-  have h : qdr_cvx.point₂ ≠ qdr_cvx.point₄ ∧ qdr_cvx.point₃ ≠ qdr_cvx.point₁ := ⟨qdr_cvx.nd₂₄.symm, qdr_cvx.nd₁₃⟩
-  simp only [ne_eq, h, not_false_eq_true, and_self, dite_true]
+  simp only [ne_eq, pt_ne, not_false_eq_true, and_self, dite_true]
   have g: ¬ qdr_cvx.diag_nd₁₃ ∥ qdr_cvx.diag_nd₂₄ := qdr_cvx.diag_not_para
   rw [diag_nd₁₃, diag_nd₂₄] at g
-  have g': ¬ (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁ h.2.symm) ∥ (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ h.1.symm) := by
+  have g': ¬ (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁) ∥ (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄) := by
     apply Ne.symm (SegND.not_para_rev_of_not_para (Ne.symm g))
   simp only [g', not_false_eq_true, dite_true]
-  have g'': ¬ (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ h.1.symm) ∥ (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁ h.2.symm) := Ne.symm g'
-  have nd₃₁_eq_nd₁₃ : (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁ qdr_cvx.nd₁₃.symm).toLine = (SEG_nd qdr_cvx.point₁ qdr_cvx.point₃ qdr_cvx.nd₁₃).toLine := by
-    exact (Line.line_of_pt_pt_eq_rev qdr_cvx.nd₁₃.symm)
-  have inx_eq : qdr_cvx.diag_inx = LineInx (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ qdr_cvx.nd₂₄).toLine (SEG_nd qdr_cvx.point₁ qdr_cvx.point₃ qdr_cvx.nd₁₃).toLine (Ne.symm qdr_cvx.diag_not_para) := Eq.symm (Line.inx.symm (SegND.not_para_toLine_of_not_para qdr_cvx.diag_nd₁₃ qdr_cvx.diag_nd₂₄ qdr_cvx.diag_not_para))
+  have g'': ¬ (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄) ∥ (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁) := Ne.symm g'
+  have nd₃₁_eq_nd₁₃ : (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁).toLine = (SEG_nd qdr_cvx.point₁ qdr_cvx.point₃).toLine := by
+    exact Line.line_of_pt_pt_eq_rev (_h := qdr_cvx.nd₁₃.symm)
+  have inx_eq : qdr_cvx.diag_inx = LineInx (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄).toLine (SEG_nd qdr_cvx.point₁ qdr_cvx.point₃).toLine (Ne.symm qdr_cvx.diag_not_para) := Eq.symm (Line.inx.symm (SegND.not_para_toLine_of_not_para qdr_cvx.diag_nd₁₃ qdr_cvx.diag_nd₂₄ qdr_cvx.diag_not_para))
   rcases qdr_cvx.diag_inx_lies_int with ⟨a, b⟩
-  have inx_eq' : qdr_cvx.diag_inx = Line.inx (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄ qdr_cvx.nd₂₄).toLine (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁ qdr_cvx.nd₁₃.symm).toLine g'':= by
+  have inx_eq' : qdr_cvx.diag_inx = Line.inx (SEG_nd qdr_cvx.point₂ qdr_cvx.point₄).toLine (SEG_nd qdr_cvx.point₃ qdr_cvx.point₁).toLine g'':= by
     rw [inx_eq]
     congr 1
     exact nd₃₁_eq_nd₁₃.symm
@@ -187,11 +183,10 @@ theorem permute_is_convex : (QDR qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point
   exact ⟨b, (Seg.lies_int_rev_iff_lies_int.mp a)⟩
 
 /-- Given a convex quadrilateral qdr_cvx, edge from the first point to the second point is not degenerate, i.e. the second point is not equal to the first point. -/
-theorem nd₁₂ : qdr_cvx.point₂ ≠ qdr_cvx.point₁ := by
-  have h: qdr_cvx.point₁ ≠ qdr_cvx.point₃ ∧ qdr_cvx.point₂ ≠ qdr_cvx.point₄ := ⟨qdr_cvx.nd₁₃.symm, qdr_cvx.nd₂₄.symm⟩
+instance nd₁₂ : PtNe qdr_cvx.point₂ qdr_cvx.point₁ := Fact.mk <| by
   have k: qdr_cvx.IsConvex := convex _
   unfold Quadrilateral.IsConvex at k
-  simp only [ne_eq, h, not_false_eq_true, and_self, dite_true] at k
+  simp only [ne_eq, pt_ne, not_false_eq_true, and_self, dite_true] at k
   have g: ¬ qdr_cvx.diag_nd₂₄ ∥ qdr_cvx.diag_nd₁₃ := Ne.symm qdr_cvx.diag_not_para
   rw [diag_nd₁₃, diag_nd₂₄] at g
   simp only [g, dite_true] at k
@@ -209,41 +204,41 @@ theorem nd₁₂ : qdr_cvx.point₂ ≠ qdr_cvx.point₁ := by
   exact point₁_not_lies_int_diag_nd₁₃ point₁_lies_int_diag_nd₁₃
 
 /-- Given a convex quadrilateral qdr_cvx, edge from the 2nd point to the 3rd point is not degenerate, i.e. the second point is not equal to the first point. -/
-theorem nd₂₃ : qdr_cvx.point₃ ≠ qdr_cvx.point₂ := by
+instance nd₂₃ : PtNe qdr_cvx.point₃ qdr_cvx.point₂ := Fact.mk <| by
   let permute := (QDR qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁)
   have h : permute IsConvex := permute_is_convex qdr_cvx
   let permute_convex := mk_is_convex h
-  exact permute_convex.nd₁₂
+  exact permute_convex.nd₁₂.out
 
 /-- Given a convex quadrilateral qdr_cvx, edge from the 3rd point to the 4th point is not degenerate, i.e. the second point is not equal to the first point. -/
-theorem nd₃₄ : qdr_cvx.point₄ ≠ qdr_cvx.point₃ := by
+instance nd₃₄ : PtNe qdr_cvx.point₄ qdr_cvx.point₃ := Fact.mk <| by
   let permute := (QDR qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁)
   have h : permute IsConvex := permute_is_convex qdr_cvx
   let permute_convex := mk_is_convex h
-  exact permute_convex.nd₂₃
+  exact permute_convex.nd₂₃.out
 
 /-- Given a convex quadrilateral qdr_cvx, edge from the 1st point to the 4th point is not degenerate, i.e. the second point is not equal to the first point. -/
-theorem nd₁₄ : qdr_cvx.point₄ ≠ qdr_cvx.point₁ := by
+instance nd₁₄ : PtNe qdr_cvx.point₄ qdr_cvx.point₁ := Fact.mk <| by
   let permute := (QDR qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁)
   have h : permute IsConvex := permute_is_convex qdr_cvx
   let permute_convex := mk_is_convex h
-  exact permute_convex.nd₃₄.symm
+  exact permute_convex.nd₃₄.out.symm
 
 /-- The edge from the first point to the second point of a quadrilateral -/
 @[pp_dot]
-def edge_nd₁₂ : SegND P := SEG_nd qdr_cvx.point₁ qdr_cvx.point₂ (qdr_cvx.nd₁₂)
+def edge_nd₁₂ : SegND P := SEG_nd qdr_cvx.point₁ qdr_cvx.point₂
 
 /-- The edge from the second point to the third point of a quadrilateral -/
 @[pp_dot]
-def edge_nd₂₃ : SegND P := SEG_nd qdr_cvx.point₂ qdr_cvx.point₃ (qdr_cvx.nd₂₃)
+def edge_nd₂₃ : SegND P := SEG_nd qdr_cvx.point₂ qdr_cvx.point₃
 
 /-- The edge from the third point to the fourth point of a quadrilateral -/
 @[pp_dot]
-def edge_nd₃₄ : SegND P := SEG_nd qdr_cvx.point₃ qdr_cvx.point₄ (qdr_cvx.nd₃₄)
+def edge_nd₃₄ : SegND P := SEG_nd qdr_cvx.point₃ qdr_cvx.point₄
 
 /-- The edge from the fourth point to the first point of a quadrilateral -/
 @[pp_dot]
-def edge_nd₁₄ : SegND P := SEG_nd qdr_cvx.point₁ qdr_cvx.point₄ (qdr_cvx.nd₁₄)
+def edge_nd₁₄ : SegND P := SEG_nd qdr_cvx.point₁ qdr_cvx.point₄
 
 /-- Given a convex quadrilateral qdr_cvx, its 1st, 2nd and 3rd points are not colinear, i.e. the projective direction of the vector $\overrightarrow{point₁ point₂}$ is not the same as the projective direction of the vector $\overrightarrow{point₁ point₃}$. -/
 theorem not_colinear₁₂₃ : ¬ colinear qdr_cvx.1.1 qdr_cvx.1.2 qdr_cvx.1.3 := sorry
@@ -279,19 +274,19 @@ theorem not_colinear₁₂₄ : ¬ colinear qdr_cvx.1.1 qdr_cvx.1.2 qdr_cvx.1.4 
 
 /--angle at point₁ of qdr_cvx-/
 @[pp_dot]
-def angle₁ : Angle P := ANG qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.point₂ qdr_cvx.nd₁₄ qdr_cvx.nd₁₂
+def angle₁ : Angle P := ANG qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.point₂
 
 /--angle at point₂ of qdr_cvx-/
 @[pp_dot]
-def angle₂ : Angle P := ANG qdr_cvx.point₁ qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.nd₁₂.symm qdr_cvx.nd₂₃
+def angle₂ : Angle P := ANG qdr_cvx.point₁ qdr_cvx.point₂ qdr_cvx.point₃
 
 /--angle at point₃ of qdr_cvx-/
 @[pp_dot]
-def angle₃ : Angle P := ANG qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.nd₂₃.symm qdr_cvx.nd₃₄
+def angle₃ : Angle P := ANG qdr_cvx.point₂ qdr_cvx.point₃ qdr_cvx.point₄
 
 /--angle at point₄ of qdr_cvx-/
 @[pp_dot]
-def angle₄ : Angle P := ANG qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁ qdr_cvx.nd₃₄.symm qdr_cvx.nd₁₄.symm
+def angle₄ : Angle P := ANG qdr_cvx.point₃ qdr_cvx.point₄ qdr_cvx.point₁
 
 /--triangle point₄ point₁ point₂, which includes angle₁-/
 @[pp_dot]

--- a/EuclideanGeometry/Foundation/Construction/Triangle/AngleBisector.lean
+++ b/EuclideanGeometry/Foundation/Construction/Triangle/AngleBisector.lean
@@ -152,10 +152,10 @@ theorem exangbisline_is_exangbisline : sorry := sorry
 end Angle
 
 /-definition property: lies on the bis means bisect the angle-/
-theorem lie_on_angbis (ang: Angle P) (A : P) (h : A ≠ ang.source): A LiesOn ang.AngBis ↔ IsAngBis ang (RAY _ _ h) := by
+theorem lie_on_angbis (ang: Angle P) (A : P) [h : PtNe A ang.source]: A LiesOn ang.AngBis ↔ IsAngBis ang (RAY ang.source A) := by
   rw [Angle.angbis_iff_angbis]
-  exact ⟨fun g ↦ (by rw [← Ray.pt_pt_eq_ray ⟨g, h⟩]; rfl),
-    fun g ↦ (by rw [← g]; exact Ray.snd_pt_lies_on_mk_pt_pt h)⟩
+  exact ⟨fun g ↦ (by rw [← Ray.pt_pt_eq_ray ⟨g, h.out⟩]; rfl),
+    fun g ↦ (by rw [← g]; exact Ray.snd_pt_lies_on_mk_pt_pt (h := h))⟩
 
 /- underlying line of bis as the locus satisfying the sum of distance to each ray of the angle is 0 -/
 theorem lie_on_angbisline_of_distance_zero (ang: Angle P) : sorry := sorry


### PR DESCRIPTION
Todo:
`PtReduce` typeclass to help infer `PtNe` instance (we cannot use tactics such as `dsimp` when inferring a instance)
`NonCollinear` typeclass
try to replace `XxxND` (and some other variants) with `Xxx.IsND` typeclasses

- [x] depends on: #260
- [x] depends on: #262