### PR TITLE
Update AddToMathlib.lean, Vector.lean, Line.lean and Position/Angle.lean

### DIFF
--- a/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
@@ -260,6 +260,10 @@ theorem eq_coe_of_toReal_eq {x : ℝ} (h : θ.toReal = x) : θ = ∠[x] :=
 
 theorem neg_pi_le_toReal : - π ≤ θ.toReal := le_of_lt θ.neg_pi_lt_toReal
 
+instance instCircularOrderedAddCommGroup : CircularOrderedAddCommGroup AngValue :=
+  haveI hp : Fact (0 < 2 * π) := ⟨two_pi_pos⟩
+  QuotientAddGroup.instCircularOrderedAddCommGroup ℝ
+
 end
 
 section composite
@@ -1198,6 +1202,7 @@ variable (θ : AngValue)
 -- `We shall wait and see what congruence will become`
 -/
 
+/-- The absolute value of an angle $θ$ is the absolute value of $θ.toReal$. -/
 def abs (θ : AngValue) : ℝ := |θ.toReal|
 
 theorem zero_le_abs : 0 ≤ θ.abs := abs_nonneg θ.toReal
@@ -1415,6 +1420,7 @@ end acute_obtuse
 
 section norm
 
+/-- The absolute value of an angle is equal to its norm. -/
 theorem abs_eq_norm : θ.abs = ‖θ‖ := by
   apply le_antisymm
   · refine' le_csInf ⟨θ.abs, θ.toReal, θ.coe_toReal, rfl⟩ (fun a h ↦ _)
@@ -1437,9 +1443,12 @@ end abs
 
 section half
 
-/-- Half of an angle. Note that there are two possible values when dividing by two in `AngValue` (their difference is `π`). We choose the acute angle as the canonical value for half of an angle for angles not equal to `π`, and the half of `π` is defined as `π / 2`. -/
+/-- Half of an angle. Note that there are two possible values when dividing by two in `AngValue`
+(their difference is `π`). We choose the acute angle as the canonical value for half of an angle
+for angles not equal to `π`, and the half of `π` is defined as `π / 2`. -/
 def half (θ : AngValue) : AngValue := ∠[θ.toReal / 2]
 -- Do we need the other value obatined by dividing by two, i.e., `θ.half + π`?
+-- Do we need a class `IsHalf`?
 
 theorem coe_half {x : ℝ} (hn : - π < x) (h : x ≤ π) : ∠[x].half = ∠[x / 2] :=
   congrArg AngValue.coe (congrFun (congrArg HDiv.hDiv (toReal_coe_eq_self hn h)) 2)

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Angle.lean
@@ -32,6 +32,10 @@ instance : NormedAddCommGroup AngDValue :=
 instance : Inhabited AngDValue :=
   inferInstanceAs (Inhabited (AddCircle π))
 
+instance instCircularOrderedAddCommGroup : CircularOrderedAddCommGroup AngDValue :=
+  haveI hp : Fact (0 < π) := ⟨pi_pos⟩
+  QuotientAddGroup.instCircularOrderedAddCommGroup ℝ
+
 @[coe]
 def _root_.EuclidGeom.AngValue.toAngDValue : AngValue → AngDValue :=
   Quotient.map' id (by

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Angle/AddToMathlib.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Angle/AddToMathlib.lean
@@ -6,13 +6,17 @@ import EuclideanGeometry.Foundation.Axiom.Basic.Angle.FromMathlib
 Maybe we can create some PRs to mathlib in the future.
 -/
 
-open Real
+open Real Classical
 
 /-!
-## More theorems about trigonometric functions in Mathlib
+### More theorems about trigonometric functions in Mathlib
 
-These theorems about trigonometric functions mostly exist in Mathlib in the version of `Real.sin`, `Real.cos` or `Real.tan` but not in the version of `Real.Angle.sin`, `Real.Angle.cos` or `Real.Angle.tan`.
-In this file, we will translate these theorems into the version of `EuclidGeom.AngValue.sin`, `EuclidGeom.AngValue.cos` or `EuclidGeom.AngValue.tan`.
+These theorems about trigonometric functions mostly exist in Mathlib in the version of `Real.sin`,
+`Real.cos` or `Real.tan` but not in the version of `Real.Angle.sin`, `Real.Angle.cos` or
+`Real.Angle.tan`.
+
+In this section, we will translate these theorems into the version of `EuclidGeom.AngValue.sin`,
+`EuclidGeom.AngValue.cos` or `EuclidGeom.AngValue.tan`.
 -/
 
 namespace EuclidGeom
@@ -391,52 +395,557 @@ end EuclidGeom
 
 
 /-!
-## Compatibility among group, addtorsor and order
+### Compatibility among group, addtorsor and order
 -/
 
 section Mathlib.Algebra.Order.Group.Defs
 
-class CircularOrderAddCommGroup (G : Type*) extends AddCommGroup G, CircularOrder G where
-  btw_add {a b c : G} (h : btw a b c) (t : G) : btw (a + t) (b + t) (c + t)
+/-- A circular ordered additive commutative group is an additive commutative group with
+a circular order whose order is stable under addition and compatiable with negation. -/
+class CircularOrderedAddCommGroup (G : Type*) extends AddCommGroup G, CircularOrder G where
+  btw_add_left {a b c : G} (h : btw a b c) (g : G) : btw (g + a) (g + b) (g + c)
+  btw_neg {a b c : G} (h : btw a b c) : btw (- a) (- c) (- b)
 
-namespace CircularOrderAddCommGroup
+/-- A circular ordered commutative group is a commutative group with a circular order whose
+order is stable under multiplication and compatiable with inverse. -/
+@[to_additive]
+class CircularOrderedCommGroup (G : Type*) extends CommGroup G, CircularOrder G where
+  btw_mul_left {a b c : G} (h : btw a b c) (g : G) : btw (g * a) (g * b) (g * c)
+  btw_inv {a b c : G} (h : btw a b c) : btw a⁻¹ c⁻¹ b⁻¹
 
-variable {G : Type*} [CircularOrderAddCommGroup G]
+variable {G : Type*} [CircularOrderedCommGroup G]
 
-@[simp]
-theorem btw_add_iff {a b c t : G} : btw (a + t) (b + t) (c + t) ↔ btw a b c := by
-  refine' ⟨fun h ↦ _, fun h ↦ btw_add h t⟩
-  have h := btw_add h (- t)
-  simp only [add_neg_cancel_right] at h
-  exact h
+@[to_additive]
+theorem btw_mul_left {a b c : G} (h : btw a b c) (g : G) : btw (g * a) (g * b) (g * c) :=
+  CircularOrderedCommGroup.btw_mul_left h g
 
-theorem sbtw_add {a b c : G} (h : sbtw a b c) (t : G) : sbtw (a + t) (b + t) (c + t) := sorry
+@[to_additive (attr := simp)]
+theorem btw_mul_left_iff {g a b c : G} : btw (g * a) (g * b) (g * c) ↔ btw a b c :=
+  ⟨fun h ↦ by
+    rw [← inv_mul_cancel_left g a, ← inv_mul_cancel_left g b, ← inv_mul_cancel_left g c]
+    exact btw_mul_left h g⁻¹, fun h ↦ btw_mul_left h g⟩
 
-@[simp]
-theorem sbtw_add_iff {a b c t : G} : sbtw (a + t) (b + t) (c + t) ↔ sbtw a b c := sorry
+@[to_additive (attr := simp)]
+theorem sbtw_mul_left_iff {g a b c : G} : sbtw (g * a) (g * b) (g * c) ↔ sbtw a b c :=  by
+  simp only [sbtw_iff_not_btw, btw_mul_left_iff]
 
-end CircularOrderAddCommGroup
+@[to_additive]
+theorem sbtw_mul_left {a b c : G} (h : sbtw a b c) (g : G) : sbtw (g * a) (g * b) (g * c) :=
+  sbtw_mul_left_iff.mpr h
 
-instance QuotientAddGroup.instCircularOrderAddCommGroup (G : Type*) [LinearOrderedAddCommGroup G] [ha : Archimedean G] {p : G} [hp : Fact (0 < p)] : CircularOrderAddCommGroup (G ⧸ AddSubgroup.zmultiples p) := sorry
+@[to_additive (attr := simp)]
+theorem btw_mul_right_iff {a b c g : G} : btw (a * g) (b * g) (c * g) ↔ btw a b c := by
+  rw [mul_comm a g, mul_comm b g, mul_comm c g]
+  exact btw_mul_left_iff
 
-section Mathlib.Algebra.Order.Group.Defs
+@[to_additive]
+theorem btw_mul_right {a b c : G} (h : btw a b c) (g : G) : btw (a * g) (b * g) (c * g) :=
+  btw_mul_right_iff.mpr h
+
+@[to_additive (attr := simp)]
+theorem sbtw_mul_right_iff {a b c g : G} : sbtw (a * g) (b * g) (c * g) ↔ sbtw a b c :=  by
+  simp only [sbtw_iff_not_btw, btw_mul_right_iff]
+
+@[to_additive]
+theorem sbtw_mul_right {a b c : G} (h : sbtw a b c) (g : G) : sbtw (a * g) (b * g) (c * g) :=
+  sbtw_mul_right_iff.mpr h
+
+@[to_additive]
+theorem btw_inv {a b c : G} (h : btw a b c) : btw a⁻¹ c⁻¹ b⁻¹ := CircularOrderedCommGroup.btw_inv h
+
+@[to_additive (attr := simp)]
+theorem btw_inv_iff {a b c : G} : btw a⁻¹ b⁻¹ c⁻¹ ↔ btw a c b :=
+  ⟨fun h ↦ by
+    rw [← inv_inv a, ← inv_inv b, ← inv_inv c]
+    exact btw_inv h, btw_inv⟩
+
+@[to_additive]
+theorem btw_inv_iff' {a b c : G} : btw a⁻¹ b⁻¹ c⁻¹ ↔ btw c b a :=
+  btw_inv_iff.trans btw_cyclic.symm
+
+@[to_additive]
+theorem btw_inv_iff'' {a b c : G} : btw a⁻¹ b⁻¹ c⁻¹ ↔ btw b a c :=
+  btw_inv_iff.trans btw_cyclic
+
+@[to_additive]
+theorem btw_inv_iff_not_sbtw {a b c : G} : btw a⁻¹ b⁻¹ c⁻¹ ↔ ¬ sbtw a b c :=
+  btw_inv_iff'.trans btw_iff_not_sbtw
+
+@[to_additive]
+theorem not_btw_inv_iff_sbtw {a b c : G} : ¬ btw a⁻¹ b⁻¹ c⁻¹ ↔ sbtw a b c :=
+  btw_inv_iff_not_sbtw.not_left
+
+@[to_additive]
+theorem sbtw_inv_iff_not_btw {a b c : G} : sbtw a⁻¹ b⁻¹ c⁻¹ ↔ ¬ btw a b c :=
+  sbtw_iff_not_btw.trans btw_inv_iff'.not
+
+@[to_additive]
+theorem not_sbtw_inv_iff_btw {a b c : G} : ¬ sbtw a⁻¹ b⁻¹ c⁻¹ ↔ btw a b c :=
+  sbtw_inv_iff_not_btw.not_left
+
+@[to_additive (attr := simp)]
+theorem sbtw_inv_iff {a b c : G} : sbtw a⁻¹ b⁻¹ c⁻¹ ↔ sbtw a c b :=
+  sbtw_inv_iff_not_btw.trans (sbtw_iff_not_btw.symm.trans sbtw_cyclic)
+
+@[to_additive]
+theorem sbtw_inv {a b c : G} (h : sbtw a b c) : sbtw a⁻¹ c⁻¹ b⁻¹ := sbtw_inv_iff.mpr h
+
+@[to_additive]
+theorem sbtw_inv_iff' {a b c : G} : sbtw a⁻¹ b⁻¹ c⁻¹ ↔ sbtw c b a :=
+  sbtw_inv_iff.trans sbtw_cyclic.symm
+
+@[to_additive]
+theorem sbtw_inv_iff'' {a b c : G} : sbtw a⁻¹ b⁻¹ c⁻¹ ↔ sbtw b a c :=
+  sbtw_inv_iff.trans sbtw_cyclic
+
+@[to_additive]
+theorem btw_div_left {a b c : G} (h : btw a b c) (g : G) : btw (g / a) (g / c) (g / b) := by
+  simp only [div_eq_mul_inv]
+  exact btw_mul_left (btw_inv h) g
+
+@[to_additive (attr := simp)]
+theorem btw_div_left_iff {g a b c : G} : btw (g / a) (g / b) (g / c) ↔ btw a c b :=
+  ⟨fun h ↦ btw_inv_iff.mp <| by
+    simp only [div_eq_mul_inv] at h
+    exact btw_mul_left_iff.mp h, fun h ↦ btw_div_left h g⟩
+
+@[to_additive]
+theorem btw_div_left_iff' {g a b c : G} : btw (g / a) (g / b) (g / c) ↔ btw c b a :=
+  btw_div_left_iff.trans btw_cyclic.symm
+
+@[to_additive]
+theorem btw_div_left_iff'' {g a b c : G} : btw (g / a) (g / b) (g / c) ↔ btw b a c :=
+  btw_div_left_iff.trans btw_cyclic
+
+@[to_additive]
+theorem sbtw_div_left {a b c : G} (h : sbtw a b c) (g : G) : sbtw (g / a) (g / c) (g / b) := by
+  simp only [div_eq_mul_inv]
+  exact sbtw_mul_left (sbtw_inv h) g
+
+@[to_additive (attr := simp)]
+theorem sbtw_div_left_iff {a b c g : G} : sbtw (g / a) (g / b) (g / c) ↔ sbtw a c b :=
+  ⟨fun h ↦ sbtw_inv_iff.mp <| by
+    simp only [div_eq_mul_inv] at h
+    exact sbtw_mul_left_iff.mp h, fun h ↦ sbtw_div_left h g⟩
+
+@[to_additive]
+theorem sbtw_div_left_iff' {g a b c : G} : sbtw (g / a) (g / b) (g / c) ↔ sbtw c b a :=
+  sbtw_div_left_iff.trans sbtw_cyclic.symm
+
+@[to_additive]
+theorem sbtw_div_left_iff'' {g a b c : G} : sbtw (g / a) (g / b) (g / c) ↔ sbtw b a c :=
+  sbtw_div_left_iff.trans sbtw_cyclic
+
+@[to_additive]
+theorem btw_div_left_iff_not_sbtw {g a b c : G} : btw (g / a) (g / b) (g / c) ↔ ¬ sbtw a b c :=
+  btw_div_left_iff'.trans btw_iff_not_sbtw
+
+@[to_additive]
+theorem not_btw_div_left_iff_sbtw {g a b c : G} : ¬ btw (g / a) (g / b) (g / c) ↔ sbtw a b c :=
+  btw_div_left_iff_not_sbtw.not_left
+
+@[to_additive]
+theorem sbtw_div_left_iff_not_btw {g a b c : G} : sbtw (g / a) (g / b) (g / c) ↔ ¬ btw a b c :=
+  sbtw_div_left_iff'.trans sbtw_iff_not_btw
+
+@[to_additive]
+theorem not_sbtw_div_left_iff_btw {g a b c : G} : ¬ sbtw (g / a) (g / b) (g / c) ↔ btw a b c :=
+  sbtw_div_left_iff_not_btw.not_left
+
+@[to_additive]
+theorem btw_div_right {a b c : G} (h : btw a b c) (g : G) : btw (a / g) (b / g) (c / g) := by
+  simp only [div_eq_mul_inv]
+  exact btw_mul_right h g⁻¹
+
+@[to_additive (attr := simp)]
+theorem btw_div_right_iff {a b c g : G} : btw (a / g) (b / g) (c / g) ↔ btw a b c :=
+  ⟨fun h ↦ by
+    rw [← div_mul_cancel' a g, ← div_mul_cancel' b g, ← div_mul_cancel' c g]
+    exact btw_mul_right h g, fun h ↦ btw_div_right h g⟩
+
+@[to_additive]
+theorem sbtw_div_right {a b c : G} (h : sbtw a b c) (g : G) : sbtw (a / g) (b / g) (c / g) := by
+  simp only [div_eq_mul_inv]
+  exact sbtw_mul_right h g⁻¹
+
+@[to_additive (attr := simp)]
+theorem sbtw_div_right_iff {a b c g : G} : sbtw (a / g) (b / g) (c / g) ↔ sbtw a b c :=
+  ⟨fun h ↦ by
+    rw [← div_mul_cancel' a g, ← div_mul_cancel' b g, ← div_mul_cancel' c g]
+    exact sbtw_mul_right h g, fun h ↦ sbtw_div_right h g⟩
+
+namespace QuotientAddGroup
+
+instance instCircularOrderedAddCommGroup (G : Type*) [LinearOrderedAddCommGroup G] [Archimedean G] {p : G} [Fact (0 < p)] : CircularOrderedAddCommGroup (G ⧸ AddSubgroup.zmultiples p) where
+  btw_add_left := by
+    rintro ⟨⟩ ⟨⟩ ⟨⟩ h ⟨⟩
+    apply btw_coe_iff'.mpr
+    simp only [add_sub_add_left_eq_sub]
+    exact h
+  btw_neg := by
+    rintro ⟨⟩ ⟨⟩ ⟨⟩ h
+    apply btw_coe_iff.mpr
+    simp only [toIcoMod_neg, toIocMod_neg, neg_neg]
+    exact sub_le_sub_left (btw_coe_iff.mp h) p
+
+variable {G : Type*} [LinearOrderedAddCommGroup G] [Archimedean G] {p : G} [hp : Fact (0 < p)]
+
+theorem sbtw_coe_iff' {a b c : G} : sbtw (a : G ⧸ AddSubgroup.zmultiples p) b c ↔ toIocMod hp.out 0 (a - c) < toIcoMod hp.out 0 (b - c) :=
+  not_iff_not.mp (btw_iff_not_sbtw.symm.trans not_lt.symm)
+
+theorem sbtw_coe_iff {a b c : G} : sbtw (a : G ⧸ AddSubgroup.zmultiples p) b c ↔ toIocMod hp.out c a < toIcoMod hp.out c b :=
+  not_iff_not.mp (btw_iff_not_sbtw.symm.trans (btw_coe_iff.trans not_lt.symm))
+
+end QuotientAddGroup
+
+end Mathlib.Algebra.Order.Group.Defs
 
 
 
-section Mathlib.Algebra.AddTorsor
-
-variable {V : outParam Type*} {L : Type*} [outParam (AddCommGroup V)] [AddTorsor V L]
+section Mathlib.GroupTheory.GroupAction
 
 section PartialOrder
+
+/-- A partial ordered additive group action is a additive group action on a partial
+order which is stable under the additive group action. -/
+class OrderedAddAction (G : outParam Type*) (P : Type*) [outParam (AddGroup G)] extends AddAction G P, PartialOrder P where
+  vadd_left_le {a b : P} (h : a ≤ b) (g : G) : g +ᵥ a ≤ g +ᵥ b
+
+/-- A partial ordered multiplicative group action is a multiplicative group action on a partial
+order which is stable under the multiplicative group action. -/
+@[to_additive]
+class OrderedMulAction (G : outParam Type*) (P : Type*) [outParam (Group G)] extends MulAction G P, PartialOrder P where
+  smul_left_le {a b : P} (h : a ≤ b) (g : G) : g • a ≤ g • b
+
+variable {G : outParam Type*} {P : Type*} [outParam (Group G)] [OrderedMulAction G P]
+
+@[to_additive]
+theorem smul_left_le {a b : P} (h : a ≤ b) (g : G) : g • a ≤ g • b :=
+  OrderedMulAction.smul_left_le h g
+
+@[to_additive (attr := simp)]
+theorem smul_left_le_iff {g : G} {a b : P} : g • a ≤ g • b ↔ a ≤ b := by
+  refine' ⟨fun h ↦ _, fun h ↦ smul_left_le h g⟩
+  have h := smul_left_le h g⁻¹
+  simp only [inv_smul_smul] at h
+  exact h
+
+@[to_additive (attr := simp)]
+theorem smul_left_lt_iff {g : G} {a b : P} : g • a < g • b ↔ a < b := by
+  simp only [lt_iff_le_not_le, smul_left_le_iff]
+
+@[to_additive]
+theorem smul_left_lt {a b : P} (h : a < b) (g : G) : g • a < g • b := smul_left_lt_iff.mpr h
 
 end PartialOrder
 
 section LinearOrder
 
+/-- A linearly ordered additive group action is an additive group action on a linearly order which
+is stable under the additive group action. -/
+class LinearOrderedAddAction (G : outParam Type*) (P : Type*) [outParam (AddGroup G)] extends
+  OrderedAddAction G P, LinearOrder P
+
+/-- A linearly ordered multiplicative group action is a multiplicative group action on a linearly
+order which is stable under the multiplicative group action. -/
+@[to_additive]
+class LinearOrderedMulAction (G : outParam Type*) (P : Type*) [outParam (Group G)] extends
+  OrderedMulAction G P, LinearOrder P
+
+variable {G : outParam Type*} {P : Type*} [outParam (Group G)] [LinearOrderedMulAction G P]
+
+@[to_additive]
+theorem min_smul {a b : P} (g : G) : min (g • a) (g • b) = g • min a b := by
+  simp only [min_def, smul_left_le_iff]
+  if h : a ≤ b then simp only [h, ite_true]
+  else simp only [h, ite_false]
+
+@[to_additive]
+theorem max_smul {a b : P} (g : G) : max (g • a) (g • b) = g • max a b := by
+  simp only [max_def, smul_left_le_iff]
+  if h : a ≤ b then simp only [h, ite_true]
+  else simp only [h, ite_false]
+
 end LinearOrder
 
 section CircularOrder
 
+/-- A circular ordered additive group action is an additive group action on a circular order which
+is stable under the additive group action. -/
+class CircularOrderedAddAction (G : outParam Type*) (P : Type*) [outParam (AddGroup G)] extends AddAction G P, CircularOrder P where
+  btw_vadd_left {a b c : P} (h : btw a b c) (g : G) : btw (g +ᵥ a) (g +ᵥ b) (g +ᵥ c)
+
+/-- A circular ordered multiplicative group action is a multiplicative group action on a circular
+order which is stable under the multiplicative group action. -/
+@[to_additive]
+class CircularOrderedMulAction (G : outParam Type*) (P : Type*) [outParam (Group G)] extends MulAction G P, CircularOrder P where
+  btw_smul_left {a b c : P} (h : btw a b c) (g : G) : btw (g • a) (g • b) (g • c)
+
+variable {G : outParam Type*} {P : Type*} [outParam (Group G)] [CircularOrderedMulAction G P]
+
+@[to_additive]
+theorem btw_smul_left {a b c : P} (h : btw a b c) (g : G) : btw (g • a) (g • b) (g • c) :=
+  CircularOrderedMulAction.btw_smul_left h g
+
+@[to_additive (attr := simp)]
+theorem btw_smul_left_iff {g : G} {a b c : P} : btw (g • a) (g • b) (g • c) ↔ btw a b c := by
+  refine' ⟨fun h ↦ _, fun h ↦ btw_smul_left h g⟩
+  have h := btw_smul_left h g⁻¹
+  simp only [inv_smul_smul] at h
+  exact h
+
+@[to_additive (attr := simp)]
+theorem sbtw_smul_left_iff {g : G} {a b c : P} : sbtw (g • a) (g • b) (g • c) ↔ sbtw a b c :=  by
+  simp only [sbtw_iff_not_btw, btw_smul_left_iff]
+
+@[to_additive]
+theorem sbtw_smul_left {a b c : P} (h : sbtw a b c) (g : G) : sbtw (g • a) (g • b) (g • c) :=
+  sbtw_smul_left_iff.mpr h
+
 end CircularOrder
+
+end Mathlib.GroupTheory.GroupAction
+
+
+
+section Mathlib.Algebra.AddTorsor
+
+section Class
+
+section PartialOrder
+
+/-- A partial ordered `AddTorsor` of a partially ordered additive commutative group is a structure
+of an `AddTorsor` and orders on the group and the type acted on are compatiable with the additive
+group action.-/
+class OrderedAddTorsor (G : outParam Type*) (P : Type*) [outParam (OrderedAddCommGroup G)] extends OrderedAddAction G P, AddTorsor G P where
+  vadd_right_le {f g : G} (h : f ≤ g) (a : P) : f +ᵥ a ≤ g +ᵥ a
+
+variable {G : outParam Type*} {P : Type*} [outParam (OrderedAddCommGroup G)] [OrderedAddTorsor G P]
+
+theorem vadd_right_le {f g : G} (h : f ≤ g) (a : P) : f +ᵥ a ≤ g +ᵥ a :=
+  OrderedAddTorsor.vadd_right_le h a
+
+theorem vadd_right_lt {f g : G} (h : f < g) (a : P) : f +ᵥ a < g +ᵥ a :=
+  Ne.lt_of_le (fun eq ↦ h.ne (vadd_right_cancel a eq)) (vadd_right_le (le_of_lt h) a)
+
+end PartialOrder
+
+section LinearOrder
+
+variable (G : outParam Type*) (P : Type*) [outParam (LinearOrderedAddCommGroup G)]
+
+class LinearOrderedAddTorsor extends LinearOrderedAddAction G P, OrderedAddTorsor G P
+
+variable {G} {P} [outParam (LinearOrderedAddCommGroup G)] [LinearOrderedAddTorsor G P]
+
+@[simp]
+theorem vadd_right_le_iff {f g : G} {a : P} : f +ᵥ a ≤ g +ᵥ a ↔ f ≤ g :=
+  ⟨fun h ↦ not_lt.mp (fun lt ↦ (not_lt_of_le h) (vadd_right_lt lt a)), fun h ↦ vadd_right_le h a⟩
+
+@[simp]
+theorem vadd_right_lt_iff {f g : G} {a : P} : f +ᵥ a < g +ᵥ a ↔ f < g := by
+  simp only [lt_iff_not_ge, vadd_right_le_iff]
+
+@[simp]
+theorem vsub_right_le_iff {a b x : P} : a -ᵥ x ≤ b -ᵥ x ↔ a ≤ b := by
+  nth_rw 2 [← vsub_vadd a x, ← vsub_vadd b x]
+  exact vadd_right_le_iff.symm
+
+theorem vsub_right_le {a b : P} (h : a ≤ b) (x : P) : a -ᵥ x ≤ b -ᵥ x := vsub_right_le_iff.mpr h
+
+@[simp]
+theorem vsub_left_le_iff {x a b : P} : x -ᵥ a ≤ x -ᵥ b ↔ b ≤ a := by
+  rw [← neg_vsub_eq_vsub_rev a x, ← neg_vsub_eq_vsub_rev b x]
+  exact neg_le_neg_iff.trans vsub_right_le_iff
+
+theorem vsub_left_le {a b : P} (h : a ≤ b) (x : P) : x -ᵥ b ≤ x -ᵥ a := vsub_left_le_iff.mpr h
+
+end LinearOrder
+
+section CircularOrder
+
+variable (G : outParam Type*) (P : Type*) [outParam (CircularOrderedAddCommGroup G)]
+
+class CircularOrderedAddTorsor extends CircularOrderedAddAction G P, AddTorsor G P where
+  btw_vadd_right {e f g : G} (h : Btw.btw e f g) (a : P) : btw (e +ᵥ a) (f +ᵥ a) (g +ᵥ a)
+
+variable {G} {P} [outParam (CircularOrderedAddCommGroup G)] [CircularOrderedAddTorsor G P]
+
+theorem btw_vadd_right {e f g : G} (h : btw e f g) (a : P) : btw (e +ᵥ a) (f +ᵥ a) (g +ᵥ a) :=
+  CircularOrderedAddTorsor.btw_vadd_right h a
+
+theorem sbtw_vadd_right {e f g : G} (h : sbtw e f g) (a : P) : sbtw (e +ᵥ a) (f +ᵥ a) (g +ᵥ a) := by
+  by_contra hn
+  rcases (btw_vadd_right h.btw a).antisymm (btw_iff_not_sbtw.mpr hn) with eq | eq | eq
+  · rw [vadd_right_cancel a eq] at h
+    exact sbtw_irrefl_left h
+  · rw [vadd_right_cancel a eq] at h
+    exact sbtw_irrefl_right h
+  · rw [vadd_right_cancel a eq] at h
+    exact sbtw_irrefl_left_right h
+
+@[simp]
+theorem btw_vadd_right_iff {e f g : G} {a : P} : btw (e +ᵥ a) (f +ᵥ a) (g +ᵥ a) ↔ btw e f g :=
+  ⟨fun h ↦ btw_iff_not_sbtw.mpr (fun hs ↦ sbtw_iff_not_btw.mp (sbtw_vadd_right hs a) h),
+    fun h ↦ btw_vadd_right h a⟩
+
+@[simp]
+theorem sbtw_vadd_right_iff {e f g : G} {a : P} : sbtw (e +ᵥ a) (f +ᵥ a) (g +ᵥ a) ↔ sbtw e f g := by
+  simp only [sbtw_iff_not_btw, btw_vadd_right_iff]
+
+@[simp]
+theorem btw_vsub_right_iff {a b c x : P} : btw (a -ᵥ x) (b -ᵥ x) (c -ᵥ x) ↔ btw a b c := by
+  nth_rw 2 [← vsub_vadd a x, ← vsub_vadd b x, ← vsub_vadd c x]
+  exact btw_vadd_right_iff.symm
+
+theorem btw_vsub_right {a b c : P} (h : btw a b c) (x : P) : btw (a -ᵥ x) (b -ᵥ x) (c -ᵥ x) :=
+  btw_vsub_right_iff.mpr h
+
+@[simp]
+theorem sbtw_vsub_right_iff {a b c x : P} : sbtw (a -ᵥ x) (b -ᵥ x) (c -ᵥ x) ↔ sbtw a b c := by
+  simp only [sbtw_iff_not_btw, btw_vsub_right_iff]
+
+theorem sbtw_vsub_right {a b c : P} (h : sbtw a b c) (x : P) : sbtw (a -ᵥ x) (b -ᵥ x) (c -ᵥ x) :=
+  sbtw_vsub_right_iff.mpr h
+
+@[simp]
+theorem btw_vsub_left_iff {x a b c : P} : btw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ btw a c b := by
+  rw [← neg_vsub_eq_vsub_rev a x, ← neg_vsub_eq_vsub_rev b x, ← neg_vsub_eq_vsub_rev c x]
+  exact btw_neg_iff.trans btw_vsub_right_iff
+
+theorem btw_vsub_left {a b c : P} (h : btw a b c) (x : P) : btw (x -ᵥ a) (x -ᵥ c) (x -ᵥ b) :=
+  btw_vsub_left_iff.mpr h
+
+theorem btw_vsub_left_iff' {x a b c : P} : btw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ btw c b a :=
+  btw_vsub_left_iff.trans btw_cyclic.symm
+
+theorem btw_vsub_left_iff'' {x a b c : P} : btw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ btw b a c :=
+  btw_vsub_left_iff.trans btw_cyclic
+
+theorem btw_vsub_left_iff_not_sbtw {x a b c : P} : btw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ ¬ sbtw a b c :=
+  btw_vsub_left_iff'.trans btw_iff_not_sbtw
+
+theorem not_btw_vsub_left_iff_sbtw {x a b c : P} : ¬ btw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ sbtw a b c :=
+  btw_vsub_left_iff_not_sbtw.not_left
+
+theorem sbtw_vsub_left_iff_not_btw {x a b c : P} : sbtw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ ¬ btw a b c :=
+  sbtw_iff_not_btw.trans btw_vsub_left_iff'.not
+
+theorem not_sbtw_vsub_left_iff_btw {x a b c : P} : ¬ sbtw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ btw a b c :=
+  sbtw_vsub_left_iff_not_btw.not_left
+
+@[simp]
+theorem sbtw_vsub_left_iff {x a b c : P} : sbtw (x -ᵥ a) (x -ᵥ b) (x -ᵥ c) ↔ sbtw a c b :=
+  sbtw_vsub_left_iff_not_btw.trans (sbtw_iff_not_btw.symm.trans sbtw_cyclic)
+
+theorem sbtw_vsub_left {a b c : P} (h : sbtw a b c) (x : P) : sbtw (x -ᵥ a) (x -ᵥ c) (x -ᵥ b) :=
+  sbtw_vsub_left_iff.mpr h
+
+end CircularOrder
+
+end Class
+
+section symmetry
+-- These lemmas show that the following definitions satisfy symmetry.
+
+variable {G : outParam Type*} {P : Type*}
+
+lemma vsub_le_zero_iff_zero_le_vsub_rev [outParam (OrderedAddCommGroup G)] [AddTorsor G P] (a b : P) : a -ᵥ b ≤ 0 ↔ 0 ≤ b -ᵥ a :=
+  (add_le_add_iff_right (b -ᵥ a)).symm.trans (by rw [vsub_add_vsub_cancel, vsub_self, zero_add])
+
+lemma vsub_lt_zero_iff_zero_lt_vsub_rev [outParam (OrderedAddCommGroup G)] [AddTorsor G P] (a b : P) : a -ᵥ b < 0 ↔ 0 < b -ᵥ a :=
+  (add_lt_add_iff_right (b -ᵥ a)).symm.trans (by rw [vsub_add_vsub_cancel, vsub_self, zero_add])
+
+variable [outParam (CircularOrderedAddCommGroup G)] [AddTorsor G P] (a b c : P)
+
+lemma btw_vsub_fst_iff_btw_vsub_snd : btw 0 (b -ᵥ a) (c -ᵥ a) ↔ btw (a -ᵥ b) 0 (c -ᵥ b) :=
+  Iff.trans (by simp only [vsub_add_vsub_cancel, vsub_self, zero_add]) (btw_add_right_iff (g := b -ᵥ a))
+
+lemma btw_vsub_fst_iff_btw_vsub_trd : btw 0 (b -ᵥ a) (c -ᵥ a) ↔ btw (a -ᵥ c) (b -ᵥ c) 0 :=
+  Iff.trans (by simp only [vsub_add_vsub_cancel, vsub_self, zero_add]) (btw_add_right_iff (g := c -ᵥ a))
+
+lemma btw_vsub_snd_iff_btw_vsub_trd : btw (a -ᵥ b) 0 (c -ᵥ b) ↔ btw (a -ᵥ c) (b -ᵥ c) 0 :=
+  (btw_vsub_fst_iff_btw_vsub_snd a b c).symm.trans (btw_vsub_fst_iff_btw_vsub_trd a b c)
+
+lemma sbtw_vsub_fst_iff_sbtw_vsub_snd : sbtw 0 (b -ᵥ a) (c -ᵥ a) ↔ sbtw (a -ᵥ b) 0 (c -ᵥ b) :=
+  Iff.trans (by simp only [vsub_add_vsub_cancel, vsub_self, zero_add]) (sbtw_add_right_iff (g := b -ᵥ a))
+
+lemma sbtw_vsub_fst_iff_sbtw_vsub_trd : sbtw 0 (b -ᵥ a) (c -ᵥ a) ↔ sbtw (a -ᵥ c) (b -ᵥ c) 0 :=
+  Iff.trans (by simp only [vsub_add_vsub_cancel, vsub_self, zero_add]) (sbtw_add_right_iff (g := c -ᵥ a))
+
+lemma sbtw_vsub_snd_iff_sbtw_vsub_trd : sbtw (a -ᵥ b) 0 (c -ᵥ b) ↔ sbtw (a -ᵥ c) (b -ᵥ c) 0 :=
+  (sbtw_vsub_fst_iff_sbtw_vsub_snd a b c).symm.trans (sbtw_vsub_fst_iff_sbtw_vsub_trd a b c)
+
+end symmetry
+
+namespace AddTorsor
+
+section contruction
+
+variable (G : outParam Type*) (P : Type*)
+
+/-- If the group acting on an `AddTorsor` is a partial ordered group, then there is a natual
+partial order on the `AddTorsor` along with a corresponding structure of partial ordered `AddTorsor`
+induced by the partial ordered group. This is not an instance, since we do not want it to
+conflict with other partial order structures that may exist on the `AddTorsor`. -/
+def OrderedAddTorsor_of_OrderedAddCommGroup [outParam (OrderedAddCommGroup G)] [AddTorsor G P] : OrderedAddTorsor G P where
+  vsub_vadd' := vsub_vadd'
+  vadd_vsub' := vadd_vsub'
+  le a b := a -ᵥ b ≤ 0
+  lt a b := a -ᵥ b < 0
+  le_refl _ := by simp only [vsub_self, le_refl]
+  le_trans a b c hab hbc := (vsub_add_vsub_cancel a b c).symm.trans_le (add_nonpos hab hbc)
+  lt_iff_le_not_le a b :=
+    have h : a -ᵥ b < 0 ↔ a -ᵥ b ≤ 0 ∧ ¬ 0 ≤ a -ᵥ b := Preorder.lt_iff_le_not_le (a -ᵥ b) 0
+    ⟨fun hab ↦ ⟨(h.1 hab).1, (vsub_le_zero_iff_zero_le_vsub_rev b a).not.mpr (h.1 hab).2⟩,
+      fun ⟨hab, hba⟩ ↦ h.2 ⟨hab, (vsub_le_zero_iff_zero_le_vsub_rev b a).not.mp hba⟩⟩
+  le_antisymm a b hab hba := eq_of_vsub_eq_zero <|
+    PartialOrder.le_antisymm (a -ᵥ b) 0 hab ((vsub_le_zero_iff_zero_le_vsub_rev b a).mp hba)
+  vadd_left_le h _ := by simpa only [vadd_vsub_vadd_cancel_left] using h
+  vadd_right_le h _ := by
+    simpa only [vadd_vsub_vadd_cancel_right, tsub_le_iff_right, zero_add] using h
+
+/-- If the group acting on an `AddTorsor` is a linearly ordered group, then there is a natual
+linearly order on the `AddTorsor` along with a corresponding structure of linearly ordered `AddTorsor`
+induced by the linearly ordered group. This is not an instance, since we do not want it to
+conflict with other linearly order structures that may exist on the `AddTorsor`. -/
+theorem LinearOrderedAddTorsor_of_LinearOrderedAddCommGroup [outParam (LinearOrderedAddCommGroup G)] [AddTorsor G P] : LinearOrderedAddTorsor G P := {
+  OrderedAddTorsor_of_OrderedAddCommGroup G P with
+  le_total := fun a b ↦
+    (or_congr_right (vsub_le_zero_iff_zero_le_vsub_rev b a)).mpr (LinearOrder.le_total (a -ᵥ b) 0)
+  decidableLE := decRel fun _ ↦ _
+}
+
+/-- If the group acting on an `AddTorsor` is a circular ordered group, then there is a natual
+circular order on the `AddTorsor` along with a corresponding structure of circular ordered `AddTorsor`
+induced by the circular ordered group. This is not an instance, since we do not want it to
+conflict with other circular order structures that may exist on the `AddTorsor`. -/
+def CircularOrderedAddAction_of_CircularOrderedAddCommGroup [outParam (CircularOrderedAddCommGroup G)] [AddTorsor G P] : CircularOrderedAddTorsor G P where
+  vsub_vadd' := vsub_vadd'
+  vadd_vsub' := vadd_vsub'
+  btw a b c := btw 0 (b -ᵥ a) (c -ᵥ a)
+  sbtw a b c := sbtw 0 (b -ᵥ a) (c -ᵥ a)
+  btw_refl a := by simp only [vsub_self, btw_rfl]
+  btw_cyclic_left h := btw_cyclic_left ((btw_vsub_fst_iff_btw_vsub_snd _ _ _).mp h)
+  sbtw_iff_btw_not_btw := by
+    intro a b c
+    simp only [btw_vsub_fst_iff_btw_vsub_trd c b a]
+    exact sbtw_iff_btw_not_btw
+  sbtw_trans_left := by
+    intro a b _ _ ha h
+    have h := sbtw_add_right h (b -ᵥ a)
+    rw [zero_add, vsub_add_vsub_cancel, vsub_add_vsub_cancel] at h
+    exact sbtw_trans_left ha h
+  btw_antisymm ha h := by
+    have h := btw_antisymm ha ((btw_vsub_fst_iff_btw_vsub_trd _ _ _).mp h)
+    nth_rw 1 [vsub_left_cancel_iff, vsub_eq_zero_iff_eq, eq_comm, vsub_eq_zero_iff_eq, eq_comm] at h
+    exact h
+  btw_total := sorry
+  btw_vadd_left := sorry
+  btw_vadd_right := sorry
+
+end contruction
+
+end AddTorsor
 
 end Mathlib.Algebra.AddTorsor

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Vector.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Vector.lean
@@ -1337,7 +1337,7 @@ theorem btw_def₂ {d₁ d₂ d₃ : Dir} : btw d₁ d₂ d₃ ↔ btw (d₁ -�
 theorem btw_def₃ {d₁ d₂ d₃ : Dir} : btw d₁ d₂ d₃ ↔ btw (d₁ -ᵥ d₃) (d₂ -ᵥ d₃) 0 :=
   btw_vsub_fst_iff_btw_vsub_trd d₁ d₂ d₃
 
-theorem btw_def {d₁ d₂ d₃ : Dir} (d : Dir) : btw d₁ d₂ d₃ ↔ btw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) := by
+theorem btw_iff_btw_vsub {d₁ d₂ d₃ : Dir} (d : Dir) : btw d₁ d₂ d₃ ↔ btw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) := by
   apply (btw_add_right_iff (g := d₁ -ᵥ d)).symm.trans
   rw [zero_add, vsub_add_vsub_cancel, vsub_add_vsub_cancel]
 
@@ -1349,7 +1349,7 @@ theorem sbtw_def₂ {d₁ d₂ d₃ : Dir} : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ 
 theorem sbtw_def₃ {d₁ d₂ d₃ : Dir} : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ -ᵥ d₃) (d₂ -ᵥ d₃) 0 :=
   sbtw_vsub_fst_iff_sbtw_vsub_trd d₁ d₂ d₃
 
-theorem sbtw_def {d₁ d₂ d₃ : Dir} (d : Dir) : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) := by
+theorem sbtw_iff_sbtw_vsub {d₁ d₂ d₃ : Dir} (d : Dir) : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) := by
   apply (sbtw_add_right_iff (g := d₁ -ᵥ d)).symm.trans
   rw [zero_add, vsub_add_vsub_cancel, vsub_add_vsub_cancel]
 

--- a/EuclideanGeometry/Foundation/Axiom/Basic/Vector.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Basic/Vector.lean
@@ -1326,47 +1326,40 @@ lemma norm_unitVecND (d : Dir) : ‖d.unitVecND‖ = 1 := by
 
 section CircularOrder
 
-instance : Btw Dir where
-  btw d₁ d₂ d₃ := btw (d₁ -ᵥ d₁) (d₂ -ᵥ d₁) (d₃ -ᵥ d₁)
+instance instCircularOrderedAddTorsor : CircularOrderedAddTorsor AngValue Dir :=
+  AddTorsor.CircularOrderedAddTorsor_of_CircularOrderedAddCommGroup AngValue Dir
+
+theorem btw_def₁ {d₁ d₂ d₃ : Dir} : btw d₁ d₂ d₃ ↔ btw 0 (d₂ -ᵥ d₁) (d₃ -ᵥ d₁) := Iff.rfl
+
+theorem btw_def₂ {d₁ d₂ d₃ : Dir} : btw d₁ d₂ d₃ ↔ btw (d₁ -ᵥ d₂) 0 (d₃ -ᵥ d₂) :=
+  btw_vsub_fst_iff_btw_vsub_snd d₁ d₂ d₃
+
+theorem btw_def₃ {d₁ d₂ d₃ : Dir} : btw d₁ d₂ d₃ ↔ btw (d₁ -ᵥ d₃) (d₂ -ᵥ d₃) 0 :=
+  btw_vsub_fst_iff_btw_vsub_trd d₁ d₂ d₃
+
+theorem btw_def {d₁ d₂ d₃ : Dir} (d : Dir) : btw d₁ d₂ d₃ ↔ btw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) := by
+  apply (btw_add_right_iff (g := d₁ -ᵥ d)).symm.trans
+  rw [zero_add, vsub_add_vsub_cancel, vsub_add_vsub_cancel]
+
+theorem sbtw_def₁ {d₁ d₂ d₃ : Dir} : sbtw d₁ d₂ d₃ ↔ sbtw 0 (d₂ -ᵥ d₁) (d₃ -ᵥ d₁) := Iff.rfl
+
+theorem sbtw_def₂ {d₁ d₂ d₃ : Dir} : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ -ᵥ d₂) 0 (d₃ -ᵥ d₂) :=
+  sbtw_vsub_fst_iff_sbtw_vsub_snd d₁ d₂ d₃
+
+theorem sbtw_def₃ {d₁ d₂ d₃ : Dir} : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ -ᵥ d₃) (d₂ -ᵥ d₃) 0 :=
+  sbtw_vsub_fst_iff_sbtw_vsub_trd d₁ d₂ d₃
+
+theorem sbtw_def {d₁ d₂ d₃ : Dir} (d : Dir) : sbtw d₁ d₂ d₃ ↔ sbtw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) := by
+  apply (sbtw_add_right_iff (g := d₁ -ᵥ d)).symm.trans
+  rw [zero_add, vsub_add_vsub_cancel, vsub_add_vsub_cancel]
 
 @[simp]
-lemma btw_vadd_left {θ : AngValue} {d₁ d₂ d₃ : Dir} :
-    btw (θ +ᵥ d₁) (θ +ᵥ d₂) (θ +ᵥ d₃) ↔ btw d₁ d₂ d₃ := by
-  simp only [btw, vadd_vsub_vadd_cancel_left, vsub_self, sub_zero]
+theorem btw_neg {d₁ d₂ d₃ : Dir} : btw (- d₁) (- d₂) (- d₃) ↔ btw d₁ d₂ d₃ := by
+  rw [← pi_vadd, ← pi_vadd, ← pi_vadd, btw_vadd_left_iff]
 
 @[simp]
-lemma btw_vadd_right {θ₁ θ₂ θ₃ : AngValue} {d : Dir} :
-    btw (θ₁ +ᵥ d) (θ₂ +ᵥ d) (θ₃ +ᵥ d) ↔ btw θ₁ θ₂ θ₃ := by
-  simp only [btw, vadd_vsub_vadd_cancel_right, vsub_self, sub_zero]
-
-@[simp]
-lemma btw_vsub_right {d₁ d₂ d₃ d : Dir} :
-    btw (d₁ -ᵥ d) (d₂ -ᵥ d) (d₃ -ᵥ d) ↔ btw d₁ d₂ d₃ := by
-  simp only [btw, vsub_sub_vsub_cancel_right, vsub_self, sub_zero]
-
-@[simp]
-lemma btw_vsub_left {d d₁ d₂ d₃ : Dir} :
-    btw (d -ᵥ d₁) (d -ᵥ d₂) (d -ᵥ d₃) ↔ btw d₃ d₂ d₁ := by
-  rw [← btw_vsub_right (d := d)]
-  simp [btw]
-  sorry
-
-@[simp]
-lemma btw_neg {d₁ d₂ d₃ : Dir} :
-    btw (-d₁) (-d₂) (-d₃) ↔ btw d₁ d₂ d₃ := by
-  rw [← pi_vadd, ← pi_vadd, ← pi_vadd, btw_vadd_left]
-
-instance : CircularOrder Dir where
-  btw d₁ d₂ d₃ := btw (d₁ -ᵥ d₁) (d₂ -ᵥ d₁) (d₃ -ᵥ d₁)
-  sbtw d₁ d₂ d₃ := sbtw (d₁ -ᵥ d₁) (d₂ -ᵥ d₁) (d₃ -ᵥ d₁)
-  btw_refl d := by simpa using btw_refl _
-  btw_cyclic_left {d₁ d₂ d₃} h := by
-    simp [btw]
-    sorry
-  sbtw_iff_btw_not_btw := sorry
-  sbtw_trans_left := sorry
-  btw_antisymm := sorry
-  btw_total := sorry
+theorem sbtw_neg {d₁ d₂ d₃ : Dir} : sbtw (- d₁) (- d₂) (- d₃) ↔ sbtw d₁ d₂ d₃ := by
+  rw [← pi_vadd, ← pi_vadd, ← pi_vadd, sbtw_vadd_left_iff]
 
 end CircularOrder
 
@@ -1582,7 +1575,7 @@ theorem map_trans (f g : Dir ≃ Dir) {_ : Dir.NegCommute f} {_ : Dir.NegCommute
     Proj.map (f.trans g) = (Proj.map f).trans (Proj.map g) := by
   ext p
   induction p using Proj.ind
-  
+
   simp
 
 instance : Nonempty Proj := (nonempty_quotient_iff _).mpr <| inferInstanceAs (Nonempty Dir)

--- a/EuclideanGeometry/Foundation/Axiom/Circle/IncribedAngle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Circle/IncribedAngle.lean
@@ -200,12 +200,10 @@ theorem cangle_eq_two_times_inscribed_angle {p : P} {β : Arc P} (h₁ : p LiesO
     have : (ANG β.target β.circle.center p (Arc.center_isnot_arc_endpts β).2.symm ne).end_ray = (ANG p β.circle.center β.source ne (Arc.center_isnot_arc_endpts β).1.symm).start_ray := rfl
     have hhs : (Angle.sum_adj this).value = ∠ β.target β.circle.center β.source (Arc.center_isnot_arc_endpts β).2.symm (Arc.center_isnot_arc_endpts β).1.symm := rfl
     rw [← hhs, Angle.ang_eq_ang_add_ang_mod_pi_of_adj_ang]
-    rfl
   have hsum₂ : ∠ β.source p β.circle.center h₂.1.symm ne.symm + ∠ β.circle.center p β.target ne.symm h₂.2.symm = ∠ β.source p β.target h₂.1.symm h₂.2.symm := by
     have : (ANG β.source p β.circle.center h₂.1.symm ne.symm).end_ray = (ANG β.circle.center p β.target ne.symm h₂.2.symm).start_ray := rfl
     have hhs : (Angle.sum_adj this).value = ∠ β.source p β.target h₂.1.symm h₂.2.symm := rfl
     rw [← hhs, Angle.ang_eq_ang_add_ang_mod_pi_of_adj_ang]
-    rfl
   have eq₃ : ∠ β.target β.circle.center β.source (Arc.center_isnot_arc_endpts β).2.symm (Arc.center_isnot_arc_endpts β).1.symm + 2 • (∠ β.source p β.target h₂.1.symm h₂.2.symm) = 0 := by
     calc
       _ = ∠ β.target β.circle.center p (Arc.center_isnot_arc_endpts β).2.symm ne + ∠ p β.circle.center β.source ne (Arc.center_isnot_arc_endpts β).1.symm + 2 • (∠ β.source p β.circle.center h₂.1.symm ne.symm + ∠ β.circle.center p β.target ne.symm h₂.2.symm) := by rw [hsum₁, hsum₂]

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Line.lean
@@ -8,7 +8,8 @@ section setoid
 
 variable {P : Type _} [EuclideanPlane P]
 
-def same_dir_line : Ray P → Ray P → Prop := fun r r' => r.toDir = r'.toDir ∧ (r'.source LiesOn r ∨ r'.source LiesOn r.reverse)
+def same_dir_line : Ray P → Ray P → Prop :=
+  fun r r' => r.toDir = r'.toDir ∧ (r'.source LiesOn r ∨ r'.source LiesOn r.reverse)
 
 namespace same_dir_line
 
@@ -87,7 +88,7 @@ protected def setoid : Setoid (Ray P) where
 
 end same_extn_line
 
-theorem same_extn_line_of_PM (A : P) (x y : Dir) (h : x = y ∨ x = -y) : same_extn_line (Ray.mk A x) (Ray.mk A y) :=
+theorem same_extn_line_of_PM (A : P) {x y : Dir} (h : x = y ∨ x = -y) : same_extn_line (Ray.mk A x) (Ray.mk A y) :=
   ⟨by simp only [Ray.toProj, Dir.toProj_eq_toProj_iff, h], .inl Ray.source_lies_on⟩
 
 theorem same_extn_line.subset_carrier_union_rev_carrier {r r' : Ray P} (h : same_extn_line r r') : r'.carrier ∪ r'.reverse.carrier ⊆ r.carrier ∪ r.reverse.carrier := by
@@ -102,7 +103,8 @@ theorem same_extn_line.eq_carrier_union_rev_carrier (r r' : Ray P) (h : same_ext
   Set.Subset.antisymm_iff.mpr ⟨h.symm.subset_carrier_union_rev_carrier, h.subset_carrier_union_rev_carrier⟩
 
 -- relation between two setoids, same_dir_line implies same_extn_line
-theorem same_dir_line_le_same_extn_line : same_dir_line.setoid (P := P) ≤ same_extn_line.setoid := fun _ _ h => ⟨congr_arg Dir.toProj h.1, h.2⟩
+theorem same_dir_line_le_same_extn_line : same_dir_line.setoid (P := P) ≤ same_extn_line.setoid :=
+  fun _ _ h => ⟨congr_arg Dir.toProj h.1, h.2⟩
 
 end setoid
 
@@ -132,13 +134,15 @@ namespace Line
 def mk_pt_pt (A B : P) (h : B ≠ A) : Line P := Quotient.mk same_extn_line.setoid (RAY A B h)
 
 -- define a line from a point and a proj
-def mk_pt_proj (A : P) (proj : Proj) : Line P := proj.lift (fun x : Dir => Quotient.mk (@same_extn_line.setoid P _) <| Ray.mk A x : Dir → Line P)
-  (fun _ ↦ Quotient.sound <| same_extn_line_of_PM A _ _ (.inr rfl))
+def mk_pt_proj (A : P) (proj : Proj) : Line P :=
+  proj.lift (fun x : Dir => Quotient.mk (@same_extn_line.setoid P _) <| Ray.mk A x : Dir → Line P)
+    (fun _ ↦ Quotient.sound <| same_extn_line_of_PM A (.inr rfl))
 
 def mk_pt_dir (A : P) (dir : Dir) : Line P := mk_pt_proj A dir.toProj
 
 @[simp]
 lemma mkPtProj_toProj (A : P) (dir : Dir) : mk_pt_proj A dir.toProj = mk_pt_dir A dir := rfl
+
 -- define a line from a point and a nondegenerate vector
 def mk_pt_vec_nd (A : P) (vec_nd : VecND) : Line P := mk_pt_proj A vec_nd.toProj
 
@@ -192,13 +196,15 @@ end make
 section coercion
 
 @[pp_dot]
-def DirLine.toDir (l : DirLine P) : Dir := Quotient.lift (s := same_dir_line.setoid) (fun ray => ray.toDir) (fun _ _ h => h.left) l
+def DirLine.toDir (l : DirLine P) : Dir :=
+  Quotient.lift (s := same_dir_line.setoid) (fun ray => ray.toDir) (fun _ _ h => h.left) l
 
 @[pp_dot]
 abbrev DirLine.toProj (l : DirLine P) : Proj := l.toDir.toProj
 
 @[pp_dot]
-def DirLine.toLine (l : DirLine P) : Line P := Quotient.lift (⟦·⟧) (fun _ _ h => Quotient.sound $ same_dir_line_le_same_extn_line h) l
+def DirLine.toLine (l : DirLine P) : Line P :=
+  Quotient.lift (⟦·⟧) (fun _ _ h => Quotient.sound $ same_dir_line_le_same_extn_line h) l
 
 @[pp_dot]
 abbrev Ray.toDirLine (ray : Ray P) : DirLine P := ⟦ray⟧
@@ -207,13 +213,26 @@ abbrev Ray.toDirLine (ray : Ray P) : DirLine P := ⟦ray⟧
 abbrev SegND.toDirLine (seg_nd : SegND P) : DirLine P := seg_nd.toRay.toDirLine
 
 @[pp_dot]
-def Line.toProj (l : Line P) : Proj := Quotient.lift (s := same_extn_line.setoid) (fun ray : Ray P => ray.toProj) (fun _ _ h => h.left) l
+def Line.toProj (l : Line P) : Proj :=
+  Quotient.lift (s := same_extn_line.setoid) (fun ray : Ray P => ray.toProj) (fun _ _ h => h.left) l
 
 @[pp_dot]
 abbrev Ray.toLine (ray : Ray P) : Line P := ⟦ray⟧
 
 @[pp_dot]
 abbrev SegND.toLine (seg_nd : SegND P) : Line P := ⟦seg_nd.toRay⟧
+
+/-- An induction principle to deduce results for directed lines from those for rays,
+used with `induction l using DirLine.ind` or `induction' l using DirLine.ind with r`. -/
+@[elab_as_elim]
+protected theorem DirLine.ind {C : DirLine P → Prop} (h : ∀ (r : Ray P), C r.toDirLine) (l : DirLine P) : C l :=
+  Quotient.ind h l
+
+/-- An induction principle to deduce results for lines from those for rays,
+used with `induction l using Line.ind` or `induction' l using Line.ind with r`. -/
+@[elab_as_elim]
+protected theorem Line.ind {C : Line P → Prop} (h : ∀ (r : Ray P), C r.toLine) (l : Line P) : C l :=
+  Quotient.ind h l
 
 end coercion
 
@@ -223,7 +242,9 @@ lemma mkPtProj_toLine (A : P) (dir : Dir) : (Ray.mk A dir).toLine = Line.mk_pt_d
 
 section coercion_compatibility
 
-theorem DirLine.toLine_toProj_eq_toProj (l : DirLine P) : l.toLine.toProj = l.toProj := Quotient.ind (motive := fun l => Line.toProj (toLine l) = toProj l) (fun _ => rfl) l
+theorem DirLine.toLine_toProj_eq_toProj (l : DirLine P) : l.toLine.toProj = l.toProj := by
+  induction l using DirLine.ind
+  rfl
 
 theorem Ray.toLine_eq_toDirLine_toLine (ray : Ray P) : ray.toLine = ray.toDirLine.toLine := rfl
 
@@ -269,15 +290,16 @@ theorem Ray.toLine_carrier_eq_ray_carrier_union_rev_carrier (r : Ray P) : r.toLi
 variable {A : P} {r : Ray P} {s : SegND P}
 
 /-- A point lies on a line associated to a ray if and only if it lies on the ray or the reverse of the ray. -/
-theorem Ray.lies_on_toLine_iff_lies_on_or_lies_on_rev : (A LiesOn r.toLine) ↔ (A LiesOn r) ∨ (A LiesOn r.reverse) := Iff.rfl
+theorem Ray.lies_on_toLine_iff_lies_on_or_lies_on_rev : (A LiesOn r.toLine) ↔ (A LiesOn r) ∨ (A LiesOn r.reverse) :=
+  Iff.rfl
 
-theorem Ray.lies_on_toDirLine_iff_lies_on_or_lies_on_rev : (A LiesOn r.toDirLine) ↔ (A LiesOn r) ∨ (A LiesOn r.reverse) := Iff.rfl
+theorem Ray.lies_on_toDirLine_iff_lies_on_or_lies_on_rev : (A LiesOn r.toDirLine) ↔ (A LiesOn r) ∨ (A LiesOn r.reverse) :=
+  Iff.rfl
 
-theorem DirLine.lies_on_iff_lies_on_toLine {l : DirLine P} : (A LiesOn l.toLine) ↔ (A LiesOn l) := Iff.rfl
+theorem DirLine.lies_on_iff_lies_on_toLine {l : DirLine P} : (A LiesOn l.toLine) ↔ (A LiesOn l) :=
+  Iff.rfl
 
--- add lies on ray implies lies on ray.toLine, ray.toDirLine. Similar for seg_nd
-
--- If a point lies on a ray, then it lies on the line associated to the ray.
+/-- If a point lies on a ray, then it lies on the line associated to the ray. -/
 theorem Ray.lies_on_toLine_of_lie_on (h : A LiesOn r) : A LiesOn r.toLine := .inl h
 
 theorem SegND.lies_on_toLine_of_lie_on (h : A LiesOn s.1) : A LiesOn s.toLine :=
@@ -292,7 +314,7 @@ theorem SegND.source_lies_on_toLine : s.1.source LiesOn s.toLine :=
 theorem SegND.target_lies_on_toLine : s.1.target LiesOn s.toLine :=
   s.lies_on_toLine_of_lie_on s.1.target_lies_on
 
--- If a point lies on a ray, then it lies on the directed line associated to the ray.
+/-- If a point lies on a ray, then it lies on the directed line associated to the ray. -/
 theorem Ray.lies_on_toDirLine_of_lie_on (h : A LiesOn r) : A LiesOn r.toDirLine := .inl h
 
 theorem SegND.lies_on_toDirLine_of_lie_on (h : A LiesOn s.1) : A LiesOn s.toDirLine :=
@@ -316,10 +338,8 @@ section dirline_toRay
 def Ray.mk_pt_dirline (A : P) (l : DirLine P) (_h : A LiesOn l) : Ray P := Ray.mk A l.toDir
 
 theorem ray_of_pt_dirline_toDirLine_eq_dirline (A : P) (l : DirLine P) (h : A LiesOn l) : (Ray.mk_pt_dirline A l h).toDirLine = l := by
-  revert l
-  apply Quotient.ind
-  intro r h
-  exact Quotient.sound' $ same_dir_line.symm ⟨rfl, h⟩
+  induction l using DirLine.ind
+  exact Quotient.sound (same_dir_line.symm ⟨rfl, h⟩)
 
 theorem ray_of_pt_dirline_toDirLine_toDir_eq_dirline_toDir (A : P) (l : DirLine P) (h : A LiesOn l) : (Ray.mk_pt_dirline A l h).toDir = l.toDir := rfl
 
@@ -337,18 +357,15 @@ def reverse (l : DirLine P) : DirLine P := by
   exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨neg_inj.mpr h.1, Ray.lies_on_rev_or_lies_on_iff.mp h.2⟩
 
 theorem rev_toDir_eq_neg_toDir {l : DirLine P} : l.reverse.toDir = - l.toDir := by
-  revert l
-  rintro ⟨_⟩
+  induction l using DirLine.ind
   rfl
 
 theorem rev_rev_eq_self : l.reverse.reverse = l := by
-  revert l
-  rintro ⟨r⟩
+  induction' l using DirLine.ind with r
   exact congrArg (@Quotient.mk _ same_dir_line.setoid) r.rev_rev_eq_self
 
 theorem lies_on_rev_iff_lies_on {A : P} {l : DirLine P} : A LiesOn l.reverse ↔ A LiesOn l := by
-  revert l
-  rintro ⟨r⟩
+  induction' l using DirLine.ind with r
   exact (r.lies_on_rev_or_lies_on_iff).symm
 
 end reverse
@@ -358,19 +375,18 @@ section line_dirline_compatibility
 variable (l : DirLine P) {l₁ l₂ : DirLine P}
 
 theorem rev_toLine_eq_toLine : l.reverse.toLine = l.toLine := by
-  revert l
-  rintro ⟨_⟩
+  induction l using DirLine.ind
   exact (@Quotient.eq _ same_extn_line.setoid _ _).mpr same_extn_line.ray_rev_of_same_extn_line.symm
 
 theorem eq_of_toDir_eq_of_toLine_eq (h : l₁.toLine = l₂.toLine) (hd : l₁.toDir = l₂.toDir) : l₁ = l₂ := by
-  revert l₁ l₂
-  rintro ⟨_⟩ ⟨_⟩ h hd
-  exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨hd, ((@Quotient.eq _ same_extn_line.setoid _ _).mp h).2⟩
+  induction l₁ using DirLine.ind
+  induction l₂ using DirLine.ind
+  exact (@Quotient.eq _ same_dir_line.setoid _ _).2 ⟨hd, ((@Quotient.eq _ same_extn_line.setoid _ _).1 h).2⟩
 
 theorem eq_rev_of_toDir_eq_neg_of_toLine_eq (h : l₁.toLine = l₂.toLine) (hd : l₁.toDir = - l₂.toDir) : l₁ = l₂.reverse := by
-  revert l₁ l₂
-  rintro ⟨_⟩ ⟨_⟩ h hd
-  exact (@Quotient.eq _ same_dir_line.setoid _ _).mpr ⟨hd, ((@Quotient.eq _ same_extn_line.setoid _ _).mp h).2⟩
+  induction l₁ using DirLine.ind
+  induction l₂ using DirLine.ind
+  exact (@Quotient.eq _ same_dir_line.setoid _ _).2 ⟨hd, ((@Quotient.eq _ same_extn_line.setoid _ _).1 h).2⟩
 
 theorem eq_rev_of_toDir_ne_of_toLine_eq (h : l₁.toLine = l₂.toLine) (hd : l₁.toDir ≠ l₂.toDir) : l₁ = l₂.reverse :=
   have hp : l₁.toProj = l₂.toProj := by rw [← l₁.toLine_toProj_eq_toProj, h, l₂.toLine_toProj_eq_toProj]
@@ -391,25 +407,27 @@ variable (A B : P) [h : PtNe B A] (ray : Ray P) (seg_nd : SegND P)
 section pt_pt
 
 theorem line_of_pt_pt_eq_rev {A B : P} [_h : PtNe B A] : LIN A B = LIN B A :=
-  (Quotient.eq (r := same_extn_line.setoid)).mpr ⟨Ray.toProj_eq_toProj_of_mk_pt_pt, .inl (Ray.snd_pt_lies_on_mk_pt_pt (B := B))⟩
+  (Quotient.eq (r := same_extn_line.setoid)).mpr
+    ⟨Ray.toProj_eq_toProj_of_mk_pt_pt, .inl (Ray.snd_pt_lies_on_mk_pt_pt (B := B))⟩
 
-theorem fst_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : A LiesOn LIN A B := .inl Ray.source_lies_on
+theorem fst_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : A LiesOn LIN A B :=
+  .inl Ray.source_lies_on
 
 theorem snd_pt_lies_on_mk_pt_pt {A B : P} [_h : PtNe B A] : B LiesOn LIN A B := by
   rw [line_of_pt_pt_eq_rev]
   exact fst_pt_lies_on_mk_pt_pt
 
--- The first point and the second point in Line.mk_pt_pt LiesOn the line it make.
+-- The first point and the second point in `Line.mk_pt_pt` LiesOn the line it make.
 theorem pt_lies_on_line_of_pt_pt_of_ne {A B : P} [_h : PtNe B A] : A LiesOn LIN A B ∧ B LiesOn LIN A B :=
   ⟨fst_pt_lies_on_mk_pt_pt, snd_pt_lies_on_mk_pt_pt⟩
 
--- two point determines a line
+/-- two point determines a line. -/
 theorem eq_line_of_pt_pt_of_ne {A B : P} {l : Line P} [_h : PtNe B A] (ha : A LiesOn l) (hb : B LiesOn l) : LIN A B = l := by
-  revert l
-  rintro ⟨r⟩ ha hb
-  exact (Quotient.eq (r := same_extn_line.setoid)).mpr (same_extn_line.symm ⟨ray_toProj_eq_mk_pt_pt_toProj ha hb, ha⟩)
+  induction' l using Line.ind with r
+  exact (Quotient.eq (r := same_extn_line.setoid)).mpr <|
+    same_extn_line.symm ⟨ray_toProj_eq_mk_pt_pt_toProj ha hb, ha⟩
 
--- If two lines have two distinct intersection points, then these two lines are identical.
+/-- If two lines have two distinct intersection points, then these two lines are identical. -/
 theorem eq_of_pt_pt_lies_on_of_ne {A B : P} [_h : PtNe B A] {l₁ l₂ : Line P} (hA₁ : A LiesOn l₁) (hB₁ : B LiesOn l₁) (hA₂ : A LiesOn l₂) (hB₂ : B LiesOn l₂) : l₁ = l₂ := by
   rw [← eq_line_of_pt_pt_of_ne hA₁ hB₁]
   exact eq_line_of_pt_pt_of_ne hA₂ hB₂
@@ -448,13 +466,11 @@ theorem proj_eq_of_mk_pt_proj (proj : Proj) : (Line.mk_pt_proj A proj).toProj = 
   rfl
 
 theorem mk_pt_proj_eq {A : P} {l : Line P} (h : A LiesOn l) : Line.mk_pt_proj A l.toProj = l := by
-  obtain ⟨r⟩ := l
-  rw [mk_pt_proj, toProj]
-  conv_lhs =>
-    congr; · skip
-    exact @Quotient.lift_mk _ _ (_) (fun ray : Ray P => ray.toProj) _ r
-  refine' (Proj.lift_dir_toProj _ _ _).trans <| Quotient.sound _
-  sorry
+  induction' l using Line.ind with r
+  exact (@Quotient.map_mk _ _ ((RayVector.Setoid ℝ Vec).correspondence ⟨projectivizationSetoid ℝ Vec, _⟩)
+    same_extn_line.setoid (fun x ↦ Ray.mk A x)
+      (fun _ _ h ↦ same_extn_line_of_PM A (Dir.toProj_eq_toProj_iff.mp (Quotient.sound h))) r.2).trans <|
+        (@Quotient.eq _ same_extn_line.setoid _ _).mpr (same_extn_line.symm ⟨rfl, h⟩)
 
 theorem mk_pt_proj_eq_of_eq_toProj {A : P} {l : Line P} (h : A LiesOn l) {x : Proj} (hx : x = l.toProj) : Line.mk_pt_proj A x = l := by
   rw [hx]
@@ -497,15 +513,15 @@ theorem pt_lies_on_of_mk_pt_vec_nd (vec_nd : VecND) : A LiesOn mk_pt_vec_nd A ve
 theorem dir_eq_of_mk_pt_dir (dir : Dir) : (mk_pt_dir A dir).toDir = dir := rfl
 
 theorem mk_pt_dir_eq {A : P} {l : DirLine P} (h : A LiesOn l) : mk_pt_dir A l.toDir = l := by
-  revert l
-  rintro ⟨r⟩ h
+  induction l using DirLine.ind
   exact Eq.symm ((Quotient.eq (r := same_dir_line.setoid)).mpr ⟨rfl, h⟩)
 
 theorem mk_pt_dir_eq_of_eq_toDir {A : P} {l : DirLine P} (h : A LiesOn l) {x : Dir} (hx : x = l.toDir) : mk_pt_dir A x = l := by
   rw [hx]
   exact mk_pt_dir_eq h
 
--- If two directed lines have a intersection point and the same direction, then these two directed lines are identical.
+/-- If two directed lines have a intersection point and the same direction,
+then these two directed lines are identical. -/
 theorem eq_of_same_toDir_and_pt_lies_on {A : P} {l₁ l₂ : DirLine P} (h₁ : A LiesOn l₁) (h₂ : A LiesOn l₂) (h : l₁.toDir = l₂.toDir) : l₁ = l₂ := by
   rw [← mk_pt_dir_eq h₁, mk_pt_dir_eq_of_eq_toDir h₂ h]
 
@@ -553,9 +569,11 @@ theorem SegND.toLine_eq_extn_toLine {s : SegND P} : s.toLine = s.extension.toLin
   (Quotient.eq (r := same_extn_line.setoid)).mpr ⟨ SegND.extn_toProj.symm,
   .inl (SegND.lies_on_toRay_of_lies_on Seg.target_lies_on)⟩
 
-theorem ray_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toLine = LIN A B := rfl
+theorem ray_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toLine = LIN A B :=
+  rfl
 
-theorem seg_nd_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} [_h : PtNe B A] : (SEG_nd A B).toLine = LIN A B := rfl
+theorem seg_nd_of_pt_pt_toLine_eq_line_of_pt_pt {A B : P} [_h : PtNe B A] : (SEG_nd A B).toLine = LIN A B :=
+  rfl
 
 theorem Ray.toDirLine_rev_eq_rev_toLine {r : Ray P} : r.toDirLine.reverse = r.reverse.toDirLine :=
   (Quotient.eq (r := same_dir_line.setoid)).mpr ⟨rfl, .inl r.source_lies_on_rev⟩
@@ -563,16 +581,19 @@ theorem Ray.toDirLine_rev_eq_rev_toLine {r : Ray P} : r.toDirLine.reverse = r.re
 theorem SegND.toDirLine_eq_toRay_toDirLine {s : SegND P} : s.toRay.toDirLine = s.toDirLine := rfl
 
 theorem SegND.toDirLine_rev_eq_rev_toDirLine {s : SegND P} : s.toDirLine.reverse = s.reverse.toDirLine :=
-  (eq_dirline_of_toDir_eq_of_pt_of_ne (_h := ⟨s.2.symm⟩) (DirLine.lies_on_rev_iff_lies_on.mpr target_lies_on_toDirLine)
-    ((s.toDir_of_rev_eq_neg_toDir).trans s.toDirLine.rev_toDir_eq_neg_toDir)).symm
+  (eq_dirline_of_toDir_eq_of_pt_of_ne (_h := ⟨s.2.symm⟩)
+    (DirLine.lies_on_rev_iff_lies_on.mpr target_lies_on_toDirLine)
+      ((s.toDir_of_rev_eq_neg_toDir).trans s.toDirLine.rev_toDir_eq_neg_toDir)).symm
 
 theorem SegND.toDirLine_eq_extn_toDirLine {s : SegND P} : s.toDirLine = s.extension.toDirLine :=
-    (Quotient.eq (r := same_dir_line.setoid)).mpr
+  (Quotient.eq (r := same_dir_line.setoid)).mpr
     ⟨s.extn_toDir, .inl (s.lies_on_toRay_of_lies_on s.1.target_lies_on)⟩
 
-theorem ray_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toDirLine = DLIN A B := rfl
+theorem ray_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} [_h : PtNe B A] : (RAY A B).toDirLine = DLIN A B :=
+  rfl
 
-theorem seg_nd_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} [_h : PtNe B A] : (SEG_nd A B).toDirLine = DLIN A B := rfl
+theorem seg_nd_of_pt_pt_toDirLine_eq_dirline_of_pt_pt {A B : P} [_h : PtNe B A] : (SEG_nd A B).toDirLine = DLIN A B :=
+  rfl
 
 end coercion
 
@@ -638,12 +659,13 @@ theorem SegND.lies_on_toLine_of_lies_on_extn {X : P} {seg_nd : SegND P} (lieson 
   rw [extn_eq_rev_toRay_rev] at lieson
   exact Ray.lies_on_toLine_iff_lies_on_or_lies_on_rev.mpr (.inr lieson)
 
--- Two lines are equal iff they have the same carrier.
+/-- Two lines are equal iff they have the same carrier. -/
 theorem lies_on_iff_lies_on_iff_line_eq_line (l₁ l₂ : Line P) : (∀ A : P, A LiesOn l₁ ↔ A LiesOn l₂) ↔ l₁ = l₂ := by
   constructor
-  · revert l₁ l₂
-    rintro ⟨r₁⟩ ⟨r₂⟩ h
-    rcases r₁.toLine.nontriv with ⟨X, Y, Xrl₁, Yrl₁, neq⟩
+  · induction' l₁ using Line.ind with r
+    induction l₂ using Line.ind
+    intro h
+    rcases r.toLine.nontriv with ⟨X, Y, Xrl₁, Yrl₁, neq⟩
     exact eq_of_pt_pt_lies_on_of_ne (_h := ⟨neq⟩) Xrl₁ Yrl₁ ((h X).mp Xrl₁) ((h Y).mp Yrl₁)
   · exact fun h A ↦ Iff.of_eq (congrArg (lies_on A) h)
 
@@ -657,7 +679,8 @@ theorem Line.exist_real_vec_eq_smul_of_lies_on {A B : P} {dir : Dir} (h : B Lies
 
 theorem Line.exist_real_vec_eq_smul_vec_of_lies_on {A B : P} {v : VecND} (hb : B LiesOn (mk_pt_vec_nd A v)) : ∃ t : ℝ, VEC A B = t • v.1 :=
   if h : VEC A B = 0 then ⟨0, h.trans (zero_smul ℝ v.1).symm⟩
-  else VecND.toProj_eq_toProj_iff.mp (toProj_eq_seg_nd_toProj_of_lies_on (pt_lies_on_of_mk_pt_vec_nd A v) hb (_hab := ⟨vsub_ne_zero.mp h⟩))
+  else VecND.toProj_eq_toProj_iff.mp <|
+    toProj_eq_seg_nd_toProj_of_lies_on (pt_lies_on_of_mk_pt_vec_nd A v) hb (_hab := ⟨vsub_ne_zero.mp h⟩)
 
 theorem Line.exist_real_of_lies_on_of_pt_pt {A B C : P} [_h : PtNe B A] (hc : C LiesOn (LIN A B)) : ∃ t : ℝ, VEC A C = t • VEC A B :=
   @exist_real_vec_eq_smul_vec_of_lies_on P _ A C (SEG_nd A B).toVecND hc
@@ -674,7 +697,7 @@ theorem Line.lies_on_of_exist_real_vec_eq_smul_vec {A B : P} {v : VecND} {t : �
 theorem Line.lies_on_of_exist_real_of_pt_pt {A B C : P} [_h : PtNe B A] {t : ℝ} (ht : VEC A C = t • VEC A B) : C LiesOn (LIN A B) :=
   @lies_on_of_exist_real_vec_eq_smul_vec P _ A C (SEG_nd A B).toVecND t ht
 
-theorem Ray.subset_toDirLine {r : Ray P}: r.carrier ⊆ r.toDirLine.carrier := r.subset_toLine
+theorem Ray.subset_toDirLine {r : Ray P} : r.carrier ⊆ r.toDirLine.carrier := r.subset_toLine
 
 theorem ray_subset_dirline {r : Ray P} {l : DirLine P} (h : r.toDirLine = l) : r.carrier ⊆ l.carrier :=
   ray_subset_line (congrArg DirLine.toLine h)
@@ -743,79 +766,25 @@ namespace Line
 theorem pt_pt_linear {A B C : P} [_h : PtNe B A] (hc : C LiesOn (LIN A B)) : colinear A B C :=
   if hcb : C = B then colinear_of_trd_eq_snd A hcb
   else if hac : A = C then colinear_of_fst_eq_snd B hac
-  else
-    haveI : PtNe C B := ⟨hcb⟩
-    perm_colinear_trd_fst_snd <| (dite_prop_iff_or _).mpr <| .inr ⟨by push_neg; exact ⟨hac, Fact.out, hcb⟩,
+  else haveI : PtNe C B := ⟨hcb⟩
+  perm_colinear_trd_fst_snd <| (dite_prop_iff_or _).mpr <| .inr ⟨by push_neg; exact ⟨hac, Fact.out, hcb⟩,
     ((lies_on_iff_eq_toProj_of_lies_on snd_pt_lies_on_mk_pt_pt).mp hc).trans <|
       congrArg toProj line_of_pt_pt_eq_rev⟩
 
 theorem linear {l : Line P} {A B C : P} (h₁ : A LiesOn l) (h₂ : B LiesOn l) (h₃ : C LiesOn l) : colinear A B C := by
-  revert l
-  rintro ⟨ray⟩ a b c
-  cases a with
-  | inl a =>
-    cases b with
-    | inl b =>
-      cases c with
-      | inl c =>
-        exact Ray.colinear_of_lies_on a b c
-      | inr c =>
-        let ray' := Ray.mk C ray.toDir
-        have a' : A ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev a c
-        have b' : B ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev b c
-        exact Ray.colinear_of_lies_on a' b' Ray.source_lies_on
-    | inr b =>
-      cases c with
-      | inl c =>
-        let ray' := Ray.mk B ray.toDir
-        have a' : A ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev a b
-        have c' : C ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev c b
-        exact Ray.colinear_of_lies_on a' Ray.source_lies_on c'
-      | inr c =>
-        let ray' := Ray.mk A ray.reverse.toDir
-        have a' : A LiesOn ray.reverse.reverse := by
-          rw [Ray.rev_rev_eq_self]
-          exact a
-        have b' : B ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev b a'
-        have c' : C ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev c a'
-        exact Ray.colinear_of_lies_on ray'.source_lies_on b' c'
-  | inr a =>
-    cases b with
-    | inl b =>
-      cases c with
-      | inl c =>
-        let ray' := Ray.mk A ray.toDir
-        have b' : B ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev b a
-        have c' : C ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev c a
-        exact Ray.colinear_of_lies_on ray'.source_lies_on b' c'
-      | inr c =>
-        let ray' := Ray.mk B ray.reverse.toDir
-        have b' : B LiesOn ray.reverse.reverse := by
-          rw [Ray.rev_rev_eq_self]
-          exact b
-        have a' : A ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev a b'
-        have c' : C ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev c b'
-        exact Ray.colinear_of_lies_on a' ray'.source_lies_on c'
-    | inr b =>
-      cases c with
-      | inl c =>
-        let ray' := Ray.mk C ray.reverse.toDir
-        have c' : C LiesOn ray.reverse.reverse := by
-          rw [Ray.rev_rev_eq_self]
-          exact c
-        have a' : A ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev a c'
-        have b' : B ∈ ray'.carrier := lies_on_pt_toDir_of_pt_lies_on_rev b c'
-        exact Ray.colinear_of_lies_on  a' b' ray'.source_lies_on
-      | inr c =>
-        exact Ray.colinear_of_lies_on a b c
+  if h : B = A then exact colinear_of_snd_eq_fst C h
+  else
+  haveI : PtNe B A := ⟨h⟩
+  refine' pt_pt_linear _
+  rw [eq_line_of_pt_pt_of_ne h₁ h₂]
+  exact h₃
 
 theorem pt_pt_maximal {A B C : P} [_h : PtNe B A] (Co : colinear A B C) : C LiesOn (LIN A B) :=
   if hcb : C = B then by
     rw [hcb]
     exact snd_pt_lies_on_mk_pt_pt
-  else
-    haveI : PtNe C B := ⟨hcb⟩
-    (lies_on_iff_eq_toProj_of_lies_on snd_pt_lies_on_mk_pt_pt).mpr <|
+  else haveI : PtNe C B := ⟨hcb⟩
+  (lies_on_iff_eq_toProj_of_lies_on snd_pt_lies_on_mk_pt_pt).mpr <|
     (toProj_eq_of_colinear (perm_colinear_snd_trd_fst Co)).trans <|
       congrArg Line.toProj (line_of_pt_pt_eq_rev (_h := _h)).symm
 
@@ -883,7 +852,7 @@ section Archimedean_property
 
 namespace Line
 
--- there are two distinct points on a line
+/-- there are two distinct points on a line. -/
 theorem exists_ne_pt_pt_lies_on (A : P) {l : Line P} : ∃ B : P, B LiesOn l ∧ B ≠ A := by
   rcases l.nontriv with ⟨X, Y, hx, hy, ne⟩
   exact if h : A = X then ⟨Y, hy, ne.trans_eq h.symm⟩ else ⟨X, hx, ne_comm.mp h⟩
@@ -909,7 +878,7 @@ end Line
 
 namespace DirLine
 
--- there are two distinct points on a directed line
+/-- there are two distinct points on a directed line. -/
 theorem exists_ne_pt_pt_lies_on (A : P) {l : DirLine P} : ∃ B : P, B LiesOn l ∧ B ≠ A :=
   l.toLine.exists_ne_pt_pt_lies_on A
 
@@ -926,9 +895,11 @@ end DirLine
 
 end Archimedean_property
 
-section dist
+section addtorsor
 
-instance DirLine.instRealNormedAddTorsor (l : DirLine P) : NormedAddTorsor ℝ l.carrier.Elem where
+namespace DirLine
+
+instance instRealNormedAddTorsor (l : DirLine P) : NormedAddTorsor ℝ l.carrier.Elem where
   vadd := fun x ⟨A, ha⟩ ↦ ⟨x • l.toDir.unitVec +ᵥ A, lies_on_of_exist_real_vec_eq_smul_toDir ha (vadd_vsub _ A)⟩
   zero_vadd := by
     intro ⟨A, _⟩
@@ -966,52 +937,75 @@ instance DirLine.instRealNormedAddTorsor (l : DirLine P) : NormedAddTorsor ℝ l
     simp only [h, norm_smul, Real.norm_eq_abs, VecND.norm_coe, Dir.norm_unitVecND, mul_one,
       real_inner_smul_left, Dir.inner_unitVec, vsub_self, AngValue.cos_zero]
 
-def DirLine.ddist {l : DirLine P} {A : P} {B : P} (ha : A LiesOn l) (hb : B LiesOn l) : ℝ :=
-  (⟨B, hb⟩ : l.carrier.Elem) -ᵥ ⟨A, ha⟩
+variable {l : DirLine P} {A B C D : P} (ha : A LiesOn l) (hb : B LiesOn l) (hc : C LiesOn l) (hd : D LiesOn l)
 
-variable {V : outParam Type*} {L : Type*} [outParam (AddCommGroup V)] [AddTorsor V L] [LinearOrder V]
-  [CovariantClass V V (fun x y ↦ x + y) (fun x y ↦ x ≤ y)]
+section ddist
 
-theorem zero_le_iff_neg_le_zero (a b : L) : 0 ≤ a -ᵥ b ↔ b -ᵥ a ≤ 0 :=
-  Iff.trans (by rw [vsub_add_vsub_cancel, vsub_self, zero_add]) (add_le_add_iff_right (a -ᵥ b))
+def ddist : ℝ := (⟨B, hb⟩ : l.carrier.Elem) -ᵥ ⟨A, ha⟩
 
-instance PartialOrder_of_AddTorsor : PartialOrder L where
-  le a b := a -ᵥ b ≤ 0
-  lt a b := a -ᵥ b < 0
-  le_refl _ := by simp only [vsub_self, le_refl]
-  le_trans a b c hab hbc := (vsub_add_vsub_cancel a b c).symm.trans_le (add_nonpos hab hbc)
-  lt_iff_le_not_le a b :=
-    have hv : a -ᵥ b < 0 ↔ a -ᵥ b ≤ 0 ∧ ¬ 0 ≤ a -ᵥ b := Preorder.lt_iff_le_not_le (a -ᵥ b) 0
-    ⟨fun hab ↦ ⟨(hv.mp hab).1, (zero_le_iff_neg_le_zero a b).not.mp (hv.mp hab).2⟩,
-      fun ⟨hab, hba⟩ ↦ hv.mpr ⟨hab, (zero_le_iff_neg_le_zero a b).not.mpr hba⟩⟩
-  le_antisymm a b hab hba :=
-    eq_of_vsub_eq_zero (PartialOrder.le_antisymm (a -ᵥ b) 0 hab ((zero_le_iff_neg_le_zero a b).mpr hba))
+@[simp]
+theorem ddist_self : ddist ha ha = 0 := vsub_self _
 
-instance LinearOrder_of_AddTorsor : LinearOrder L := {
-  PartialOrder_of_AddTorsor with
-  min := fun a b ↦ if a ≤ b then a else b
-  max := fun a b ↦ if a ≤ b then b else a
-  decidableLE := decRel fun _ ↦ _
-  decidableEq := decRel fun _ ↦ _
-  decidableLT := decRel fun _ ↦ _
-  min_def := by
-    intros
-    simp only [min]
-    congr
-  max_def := by
-    intros
-    simp only [min]
-    congr
-  le_total := fun a b ↦
-    (or_congr_right (zero_le_iff_neg_le_zero a b).symm).mpr (LinearOrder.le_total (a -ᵥ b) 0)
-  compare := fun a b ↦ compareOfLessAndEq a b
-  compare_eq_compareOfLessAndEq := by
-    compareOfLessAndEq_rfl
-}
+@[simp]
+theorem neg_ddist_eq_ddist_rev : - ddist ha hb = ddist hb ha := neg_vsub_eq_vsub_rev _ _
 
-instance DirLine.instLinearOrder (l : DirLine P) : LinearOrder l.carrier.Elem :=
-  LinearOrder_of_AddTorsor
+@[simp]
+theorem ddist_eq_zero_iff_eq : ddist ha hb = 0 ↔ B = A :=
+  vsub_eq_zero_iff_eq.trans Subtype.mk_eq_mk
 
-end dist
+@[simp]
+theorem ddist_ne_zero_iff_ne : ddist ha hb ≠ 0 ↔ B ≠ A := (ddist_eq_zero_iff_eq ha hb).not
+
+@[simp]
+theorem ddist_add : ddist ha hb + ddist hb hc = ddist ha hc := by
+  rw [add_comm]
+  exact vsub_add_vsub_cancel _ _ _
+
+@[simp]
+theorem ddist_sub_right : ddist ha hb - ddist ha hc = ddist hc hb :=
+  vsub_sub_vsub_cancel_right _ _ _
+
+@[simp]
+theorem ddist_sub_left : ddist ha hc - ddist hb hc = ddist ha hb :=
+  vsub_sub_vsub_cancel_left _ _ _
+
+@[simp]
+theorem ddist_left_cancel_iff : ddist ha hb = ddist ha hc ↔ B = C :=
+  vsub_left_cancel_iff.trans Subtype.mk_eq_mk
+
+@[simp]
+theorem ddist_right_cancel_iff : ddist ha hc = ddist hb hc ↔ A = B :=
+  vsub_right_cancel_iff.trans Subtype.mk_eq_mk
+
+theorem ddist_sub_ddist_comm : ddist ha hb - ddist hc hd = ddist hd hb - ddist hc ha :=
+  vsub_sub_vsub_comm _ _ _ _
+
+theorem ddist_add_ddist_comm : ddist ha hb + ddist hc hd = ddist ha hd + ddist hc hb := by
+  rw [← neg_ddist_eq_ddist_rev hd hc]
+  apply (ddist_sub_ddist_comm ha hb hd hc).trans
+  rw [add_comm, ← neg_ddist_eq_ddist_rev hd ha]
+  rfl
+
+end ddist
+
+section order
+
+instance instOrderedAddTorsor (l : DirLine P) : OrderedAddTorsor ℝ l.carrier.Elem :=
+  AddTorsor.OrderedAddTorsor_of_OrderedAddCommGroup ℝ l.carrier.Elem
+
+instance instLinearOrderedAddTorsor (l : DirLine P) : LinearOrderedAddTorsor ℝ l.carrier.Elem :=
+  AddTorsor.LinearOrderedAddTorsor_of_LinearOrderedAddCommGroup ℝ l.carrier.Elem
+
+theorem le_iff_zero_le_ddist : (⟨A, ha⟩ : l.carrier.Elem) ≤ ⟨B, hb⟩ ↔ 0 ≤ ddist ha hb :=
+  vsub_le_zero_iff_zero_le_vsub_rev (⟨A, ha⟩ : l.carrier.Elem) ⟨B, hb⟩
+
+theorem lt_iff_zero_lt_ddist : (⟨A, ha⟩ : l.carrier.Elem) < ⟨B, hb⟩ ↔ 0 < ddist ha hb :=
+  vsub_lt_zero_iff_zero_lt_vsub_rev (⟨A, ha⟩ : l.carrier.Elem) ⟨B, hb⟩
+
+end order
+
+end DirLine
+
+end addtorsor
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Parallel.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Parallel.lean
@@ -150,37 +150,48 @@ theorem Ray.not_para_of_not_para_toDirLine (ray ray' : Ray P) : ¬ ray.toDirLine
 
 theorem Ray.not_para_iff_not_para_toDirLine (ray ray' : Ray P) : ¬ ray ∥ ray' ↔ ¬ ray.toDirLine ∥ ray'.toDirLine := ⟨id, id⟩
 
-/-- Given two parallel rays, their extension lines are parallel -/
+/-- Given two parallel rays, their extension lines are parallel. -/
 theorem Ray.para_toLine_of_para (ray ray' : Ray P) : ray ∥ ray' → ray.toLine ∥ ray'.toLine := id
 
 theorem Ray.para_of_para_toLine (ray ray' : Ray P) : ray.toLine ∥ ray'.toLine → ray ∥ ray' := id
 
 theorem Ray.para_iff_para_toLine (ray ray' : Ray P) : ray.toLine ∥ ray'.toLine ↔ ray ∥ ray' := ⟨id, id⟩
 
-/-- Given two rays, if their extension lines are not parallel, they are not parallel -/
+/-- Given two rays, if their extension lines are not parallel, they are not parallel. -/
 theorem Ray.not_para_toLine_of_not_para (ray ray' : Ray P) : ¬ ray ∥ ray' → ¬ ray.toLine ∥ ray'.toLine := id
 
 theorem Ray.not_para_of_not_para_toLine (ray ray' : Ray P) : ¬ ray.toLine ∥ ray'.toLine → ¬ ray ∥ ray' := id
 
 theorem Ray.not_para_iff_not_para_toLine (ray ray' : Ray P) : ¬ ray ∥ ray' ↔ ¬ ray.toLine ∥ ray'.toLine  := ⟨id, id⟩
 
-theorem DirLine.para_toLine_of_para (dirline dirline' : DirLine P) : dirline ∥ dirline' → dirline.toLine ∥ dirline'.toLine := Quotient.ind₂ (fun _ _ => id) dirline dirline'
+theorem DirLine.para_toLine_of_para {l₁ l₂ : DirLine P} (h : l₁ ∥ l₂) : l₁.toLine ∥ l₂.toLine := by
+  induction l₁ using DirLine.ind
+  induction l₂ using DirLine.ind
+  exact h
 
-theorem DirLine.para_of_para_toLine (dirline dirline' : DirLine P) : dirline.toLine ∥ dirline'.toLine → dirline ∥ dirline' := Quotient.ind₂ (fun _ _ => id) dirline dirline'
+theorem DirLine.para_of_para_toLine {l₁ l₂ : DirLine P} (h : l₁.toLine ∥ l₂.toLine) : l₁ ∥ l₂ := by
+  induction l₁ using DirLine.ind
+  induction l₂ using DirLine.ind
+  exact h
 
-theorem DirLine.para_iff_para_toLine (dirline dirline' : DirLine P) : dirline.toLine ∥ dirline'.toLine ↔ dirline ∥ dirline' := ⟨Quotient.ind₂ (fun _ _ => id) dirline dirline', Quotient.ind₂ (fun _ _ => id) dirline dirline'⟩
+theorem DirLine.para_toLine_iff_para (l₁ l₂ : DirLine P) : l₁.toLine ∥ l₂.toLine ↔ l₁ ∥ l₂ :=
+  ⟨para_of_para_toLine, para_toLine_of_para⟩
 
-theorem DirLine.not_para_toLine_of_not_para (dirline dirline' : DirLine P) : ¬ dirline ∥ dirline' → ¬ dirline.toLine ∥ dirline'.toLine := Quotient.ind₂ (fun _ _ => id) dirline dirline'
+theorem DirLine.not_para_toLine_iff_not_para (l₁ l₂ : DirLine P) : ¬ l₁.toLine ∥ l₂.toLine ↔ ¬ l₁ ∥ l₂ :=
+  (para_toLine_iff_para l₁ l₂).not
 
-theorem DirLine.not_para_of_not_para_toLine (dirline dirline' : DirLine P) : ¬ dirline.toLine ∥ dirline'.toLine → ¬ dirline ∥ dirline' := Quotient.ind₂ (fun _ _ => id) dirline dirline'
+theorem DirLine.not_para_toLine_of_not_para {l₁ l₂ : DirLine P} (h : ¬ l₁ ∥ l₂) : ¬ l₁.toLine ∥ l₂.toLine :=
+  (not_para_toLine_iff_not_para l₁ l₂).mpr h
 
-theorem DirLine.not_para_iff_not_para_toLine (dirline dirline' : DirLine P) : ¬ dirline ∥ dirline' ↔ ¬ dirline.toLine ∥ dirline'.toLine  := ⟨Quotient.ind₂ (fun _ _ => id) dirline dirline', Quotient.ind₂ (fun _ _ => id) dirline dirline'⟩
+theorem DirLine.not_para_of_not_para_toLine {l₁ l₂ : DirLine P} (h : ¬ l₁.toLine ∥ l₂.toLine) : ¬ l₁ ∥ l₂ :=
+  (not_para_toLine_iff_not_para l₁ l₂).mp h
 
 end parallel_iff_coercion_parallel
 
 section reverse
 
 variable {α β : Type*} [DirFig α P] [DirFig β P] {l₁ : α} {l₂ : β}
+-- Add `iff` theorems and @[simp]
 
 theorem DirFig.para_rev_of_para (h : l₁ ∥ l₂) : l₁ ∥ reverse l₂ :=
   h.trans (rev_toProj_eq_toProj l₂).symm

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
@@ -475,7 +475,7 @@ theorem Ray.lies_on_of_lies_int {X : P} {ray : Ray P} (h : X LiesInt ray) : X Li
 theorem Ray.lies_int_def {X : P} {ray : Ray P} : X LiesInt ray ↔ X LiesOn ray ∧ X ≠ ray.source := Iff.rfl
 
 
-/-- For a nondegenerate segment $AB$, every point of the segment $AB$ lies on the ray associated to $AB$.. -/
+/-- For a nondegenerate segment $AB$, every point of the segment $AB$ lies on the ray associated to $AB$. -/
 theorem SegND.lies_on_toRay_of_lies_on {X : P} {seg_nd : SegND P} (h : X LiesOn seg_nd) : X LiesOn seg_nd.toRay := by
   rcases h with ⟨t, ht0, _, h⟩
   refine' ⟨t • ‖VEC seg_nd.source seg_nd.target‖, smul_nonneg ht0 (norm_nonneg _), _⟩

--- a/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Linear/Ray.lean
@@ -62,6 +62,8 @@ structure Ray (P : Type _) [EuclideanPlane P] where
 
 attribute [pp_dot] Ray.source Ray.toDir
 
+alias Ray.mk_pt_dir := Ray.mk
+
 /-- A \emph{Segment} consists of a pair of points: the source and the target; it is the segment from the source to the target. (We allow the source and the target to be the same.) -/
 @[ext]
 structure Seg (P : Type _) [EuclideanPlane P] where

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle.lean
@@ -32,8 +32,8 @@ def mk_ray_pt (ray : Ray P) (A : P) (h : A ≠ ray.source) : Angle P where
   source_eq_source := rfl
 
 def mk_dirline_dirline (l₁ l₂ : DirLine P) (h : ¬ l₁ ∥ l₂) : Angle P where
-  start_ray := Ray.mk_pt_dirline (Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para _ _ h) ) l₁ (Line.inx_lies_on_fst (DirLine.not_para_toLine_of_not_para _ _ h))
-  end_ray := Ray.mk_pt_dirline (Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para _ _ h) ) l₂ (Line.inx_lies_on_snd (DirLine.not_para_toLine_of_not_para _ _ h))
+  start_ray := Ray.mk_pt_dirline (Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para h) ) l₁ (Line.inx_lies_on_fst (DirLine.not_para_toLine_of_not_para h))
+  end_ray := Ray.mk_pt_dirline (Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para h) ) l₂ (Line.inx_lies_on_snd (DirLine.not_para_toLine_of_not_para h))
   source_eq_source := rfl
 
 def value (A : Angle P) : AngValue := A.end_ray.toDir -ᵥ A.start_ray.toDir

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle.lean
@@ -1,58 +1,115 @@
 import EuclideanGeometry.Foundation.Axiom.Linear.Parallel
 import EuclideanGeometry.Foundation.Axiom.Basic.Angle
 
+/-!
+# Baisc definitions of angle as a figure
+
+-/
+
 noncomputable section
-open scoped Real
 
 namespace EuclidGeom
 
+/-- The angle value between two directed figures. -/
 def DirObj.AngDiff {α β} [DirObj α] [DirObj β] (F : α) (G : β) : AngValue := toDir G -ᵥ toDir F
 
 /- Define values of oriented angles, in (-π, π], modulo 2 π. -/
 /- Define oriented angles, ONLY taking in two rays starting at one point! And define ways to construct oriented angles, by given three points on the plane, and etc.  -/
+
+/-- An `Angle` is a structure of a point $P$ and two directions, which is the angle consists of
+two rays start at $P$ along with the two specified directions. -/
 @[ext]
-structure Angle (P : Type _) [EuclideanPlane P] where
-  start_ray : Ray P
-  end_ray : Ray P
-  source_eq_source : start_ray.source = end_ray.source
+structure Angle (P : Type*) [EuclideanPlane P] where
+  source : P
+  dir₁ : Dir
+  dir₂ : Dir
+
+attribute [pp_dot] Angle.source Angle.dir₁ Angle.dir₂
 
 variable {P : Type _} [EuclideanPlane P]
 
 namespace Angle
 
+alias mk_pt_dir_dir := Angle.mk
+
+/-- Given two rays with the same source, this function returns the angle consists of
+these two rays. -/
+def mk_two_ray_of_eq_source (r : Ray P) (r' : Ray P) (_h : r.source = r'.source) : Angle P where
+  source := r.source
+  dir₁ := r.toDir
+  dir₂ := r'.toDir
+
 /-- Given vertex $O$ and two distinct points $A$ and $B$, this function returns the angle formed by rays $OA$ and $OB$. We use $\verb|ANG|$ to abbreviate $\verb|Angle.mk_pt_pt_pt|$. -/
 def mk_pt_pt_pt (A O B : P) (h₁ : A ≠ O) (h₂ : B ≠ O): Angle P where
-  start_ray := Ray.mk_pt_pt O A h₁
-  end_ray := Ray.mk_pt_pt O B h₂
-  source_eq_source := rfl
+  source := O
+  dir₁ := (RAY O A h₁).toDir
+  dir₂ := (RAY O B h₂).toDir
 
-def mk_ray_pt (ray : Ray P) (A : P) (h : A ≠ ray.source) : Angle P where
-  start_ray := ray
-  end_ray := Ray.mk_pt_pt ray.source A h
-  source_eq_source := rfl
+def mk_ray_pt (r : Ray P) (A : P) (h : A ≠ r.source) : Angle P where
+  source := r.source
+  dir₁ := r.toDir
+  dir₂ := (RAY r.source A h).toDir
+
+def mk_pt_ray (A : P) (r : Ray P) (h : A ≠ r.source) : Angle P where
+  source := r.source
+  dir₁ := (RAY r.source A h).toDir
+  dir₂ := r.toDir
 
 def mk_dirline_dirline (l₁ l₂ : DirLine P) (h : ¬ l₁ ∥ l₂) : Angle P where
-  start_ray := Ray.mk_pt_dirline (Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para h) ) l₁ (Line.inx_lies_on_fst (DirLine.not_para_toLine_of_not_para h))
-  end_ray := Ray.mk_pt_dirline (Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para h) ) l₂ (Line.inx_lies_on_snd (DirLine.not_para_toLine_of_not_para h))
-  source_eq_source := rfl
+  source := Line.inx l₁.toLine l₂.toLine (DirLine.not_para_toLine_of_not_para h)
+  dir₁ := l₁.toDir
+  dir₂ := l₂.toDir
 
-def value (A : Angle P) : AngValue := A.end_ray.toDir -ᵥ A.start_ray.toDir
+variable (ang : Angle P)
 
-abbrev dvalue (A : Angle P) : AngDValue := (A.value : AngDValue)
+@[pp_dot]
+def value : AngValue := ang.dir₂ -ᵥ ang.dir₁
 
-abbrev IsND (ang : Angle P) : Prop := ang.value.IsND
+@[pp_dot]
+abbrev dvalue : AngDValue := (ang.value : AngDValue)
 
-protected def source (ang : Angle P) : P := ang.start_ray.source
+@[pp_dot]
+abbrev IsPos : Prop := ang.value.IsPos
+
+@[pp_dot]
+abbrev IsNeg : Prop := ang.value.IsNeg
+
+@[pp_dot]
+abbrev IsND : Prop := ang.value.IsND
+
+@[pp_dot]
+abbrev IsAcu : Prop := ang.value.IsAcu
+
+@[pp_dot]
+abbrev IsObt : Prop := ang.value.IsObt
+
+@[pp_dot]
+abbrev IsRight : Prop := ang.value.IsRight
+
+@[pp_dot]
+def start_ray : Ray P := ⟨ang.source, ang.dir₁⟩
+
+@[pp_dot]
+def end_ray : Ray P := ⟨ang.source, ang.dir₂⟩
+
+@[pp_dot]
+theorem start_ray_source_eq_end_ray_source : ang.start_ray.source = ang.end_ray.source := rfl
 
 end Angle
 
-theorem angle_value_eq_dir_angle (r r' : Ray P) (h : r.source = r'.source) : (Angle.mk r r' h).value = r'.toDir -ᵥ r.toDir := rfl
+theorem angle_value_eq_dir_angle (r r' : Ray P) (h : r.source = r'.source) : (Angle.mk_two_ray_of_eq_source r r' h).value = r'.toDir -ᵥ r.toDir := rfl
 
-/-- The value of $\verb|Angle.mk_pt_pt_pt| A O B$. We use ∠ to abbreviate $\verb|Angle.value_of_angle_of_three_point_nd|$.-/
-def value_of_angle_of_three_point_nd (A O B : P) (h₁ : A ≠ O) (h₂ : B ≠ O) : AngValue :=
+/-- The value of $\verb|Angle.mk_pt_pt_pt| A O B$. We use `∠` to abbreviate $\verb|Angle.value_of_angle_of_three_point_nd|$.-/
+abbrev value_of_angle_of_three_point_nd (A O B : P) (h₁ : A ≠ O) (h₂ : B ≠ O) : AngValue :=
   (Angle.mk_pt_pt_pt A O B h₁ h₂).value
 
-def value_of_angle_of_two_ray_of_eq_source (start_ray end_ray : Ray P) (h : start_ray.source = end_ray.source) : AngValue := (Angle.mk start_ray end_ray h).value
+abbrev value_of_angle_of_two_ray_of_eq_source (start_ray end_ray : Ray P) (h : start_ray.source = end_ray.source) : AngValue := (Angle.mk_two_ray_of_eq_source start_ray end_ray h).value
+
+theorem value_of_angle_of_two_ray_of_eq_source_eq_angDiff (start_ray end_ray : Ray P) (h : start_ray.source = end_ray.source) : value_of_angle_of_two_ray_of_eq_source start_ray end_ray h = DirObj.AngDiff start_ray end_ray := rfl
+
+abbrev value_of_angle_of_pt_dir_dir (O : P) (r r' : Dir) : AngValue := (Angle.mk O r r').value
+
+theorem value_of_angle_of_pt_dir_dir_eq_angDiff (O : P) (r r' : Dir) : value_of_angle_of_pt_dir_dir O r r' = DirObj.AngDiff r r' := rfl
 
 @[inherit_doc Angle.mk_pt_pt_pt]
 scoped syntax "ANG" ws term:max ws term:max ws term:max (ws term:max ws term:max)? : term
@@ -103,7 +160,7 @@ def delabValueOfAngleOfThreePointND : Delab := do
     `(∠ $A $B $C)
   else
     `(∠ $A $B $C $h₁ $h₂)
-
+/-
 namespace Angle
 
 -- `should discuss this later, is there a better definition?` ite, dite is bitter to deal with
@@ -138,27 +195,29 @@ protected theorem ison_of_isint {A : P} {ang : Angle P} : Angle.IsInt A ang → 
     simp only [f, ite_false, not_false_eq_true] at *
     constructor <;> linarith
 
-
 protected def carrier (ang : Angle P) : Set P := { p : P | Angle.IsOn p ang}
+
+instance : Fig (Angle P) P where
+  carrier := Angle.carrier
 
 protected def interior (ang : Angle P) : Set P := { p : P | Angle.IsInt p ang }
 
 instance : Interior (Angle P) P where
   interior := Angle.interior
 
-/-
-instance : IntFig Angle where
+instance : IntFig (Angle P) P where
   carrier := Angle.carrier
   interior_subset_carrier _ _ := Angle.ison_of_isint
--/
+
+theorem lies_on_of_eq {p : P} {ang : Angle P} (h : p = ang.source) : p LiesOn ang := sorry
+
+-- theorem lies_on_iff_btw_of_ptNe {p : P} {ang : Angle P} [_h : PtNe p ang.source] : p LiesOn ang ↔ btw
 
 end Angle
-
-theorem eq_end_ray_of_eq_value_eq_start_ray {ang₁ ang₂ : Angle P} (h : ang₁.start_ray = ang₂.start_ray) (v : ang₁.value = ang₂.value) : ang₁.end_ray = ang₂.end_ray := by
+ -/
+theorem eq_end_ray_of_eq_value_eq_start_ray {ang₁ ang₂ : Angle P} (h : ang₁.start_ray = ang₂.start_ray) (v : ang₁.value = ang₂.value) : ang₁.end_ray = ang₂.end_ray := sorry /-by
   ext : 1
   rw [← ang₁.source_eq_source, ← ang₂.source_eq_source, (congrArg (fun z => z.source)) h]
-  sorry
-  /-
   let g := (congrArg (fun z => AngValue.toDir z)) v
   unfold Angle.value DirObj.AngDiff Dir.AngDiff at g
   simp only [div_toangvalue_eq_toangvalue_sub, sub_todir_eq_todir_div, toangvalue_todir_eq_self] at g
@@ -168,7 +227,8 @@ theorem eq_end_ray_of_eq_value_eq_start_ray {ang₁ ang₂ : Angle P} (h : ang�
 
 theorem eq_start_ray_of_eq_value_eq_end_ray {ang₁ ang₂ : Angle P} (h : ang₁.end_ray = ang₂.end_ray) (v : ang₁.value = ang₂.value) : ang₁.start_ray = ang₂.start_ray := sorry
 
-theorem eq_of_eq_value_eq_start_ray {ang₁ ang₂ : Angle P} (h : ang₁.start_ray = ang₂.start_ray) (v : ang₁.value = ang₂.value) : ang₁ = ang₂ := Angle.ext ang₁ ang₂ h (eq_end_ray_of_eq_value_eq_start_ray h v)
+theorem eq_of_eq_value_eq_start_ray {ang₁ ang₂ : Angle P} (h : ang₁.start_ray = ang₂.start_ray) (v : ang₁.value = ang₂.value) : ang₁ = ang₂ := sorry
+  --Angle.ext ang₁ ang₂ h (eq_end_ray_of_eq_value_eq_start_ray h v)
 
 -- this section should talks about when different making methods make the same angle
 section mk_compatibility

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle_ex.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle_ex.lean
@@ -1,33 +1,40 @@
 import EuclideanGeometry.Foundation.Axiom.Position.Angle
 
+/-!
+# Constructions of an angle
+
+-/
 
 noncomputable section
 
 namespace EuclidGeom
 
+variable {P : Type _} [EuclideanPlane P]
+
 namespace Angle
 
 /- whether an angle is acute/right/obtuse. -/
 
-def IsRightAngle {P : Type _} [EuclideanPlane P] (ang : Angle P) : Prop := sorry
+def IsRightAngle (ang : Angle P) : Prop := sorry
 
 
-def IsAcuteAngle {P : Type _} [EuclideanPlane P] (ang : Angle P) : Prop := sorry
+def IsAcuteAngle (ang : Angle P) : Prop := sorry
 
 
-def IsObtuseAngle {P : Type _} [EuclideanPlane P] (ang : Angle P) : Prop := sorry
+def IsObtuseAngle (ang : Angle P) : Prop := sorry
 
 
 --`This section should be rewrite`
 /- Supplementary angles -/
 
 -- Define the supplementary angle to be the angle
-variable {P : Type _} [EuclideanPlane P] (ang : Angle P)
+variable (ang : Angle P)
 
+--Maybe the name is too long
 def supplementary : Angle P where
-  start_ray := ang.end_ray
-  end_ray := ang.start_ray.reverse
-  source_eq_source := sorry
+  source := ang.source
+  dir₁ := ang.dir₁
+  dir₂ := - ang.dir₂
 
 -- If two oriented angles share a same side, then they are supplementary oriented angles if and only if the sum of two angles is π or -π   `Do I use {ang1} or (ang1)?
 
@@ -42,9 +49,9 @@ theorem obtuse_of_supp_of_acute (rt : IsAcuteAngle ang) :  IsRightAngle ang.supp
 theorem IsND_of_supp_of_IsND (nontriv : ang.IsND) : ang.supplementary.IsND := by sorry
 
 def opposite :(Angle P) where
-  start_ray := ang.start_ray.reverse
-  end_ray := ang.end_ray.reverse
-  source_eq_source := sorry
+  source := ang.source
+  dir₁ := - ang.dir₁
+  dir₂ := - ang.dir₂
 
 theorem opposite_eq_supp_of_supp : ang.supplementary.supplementary = ang := by sorry
 
@@ -106,10 +113,15 @@ end parallel
 
 namespace Angle
 
-variable {P : Type _} [EuclideanPlane P] (ang : Angle P)
+@[pp_dot]
+def reverse (ang : Angle P) : Angle P where
+  source := ang.source
+  dir₁ := ang.dir₂
+  dir₂ := ang.dir₁
 
+theorem rev_value_eq_neg_value {ang : Angle P} : ang.reverse.value = - ang.value :=
+  (neg_vsub_eq_vsub_rev ang.reverse.dir₁ ang.reverse.dir₂).symm
 
 end Angle
-
 
 end EuclidGeom

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle_ex2.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle_ex2.lean
@@ -11,7 +11,6 @@ variable {P : Type _} [EuclideanPlane P]
 
 section AngleValue
 
-
 /- theorem - π < angle.value, angle.value ≤ π,  -/
 theorem val_gt_neg_pi (ang : Angle P) : -π < ang.value.toReal := sorry
 
@@ -19,21 +18,17 @@ theorem val_le_pi (ang : Angle P) : ang.value.toReal < π := sorry
 
 /- theorem when angle > 0, IsInt means lies left of start ray + right of end ray; when angle < 0, ...  -/
 
-theorem undefined : sorry := sorry
-
 end AngleValue
 
 section AngleSum
 
 namespace Angle
 
-theorem source_start_ray_eq_source_end_ray (ang : Angle P) : ang.start_ray.source = ang.end_ray.source := sorry
-
-
 -- Can use congrArg @Ray.source P _) h to turn h into the sources of two terms being equal.
 theorem source_eq_source_of_adj {ang₁ ang₂: Angle P} (h : ang₁.end_ray = ang₂.start_ray) : ang₁.start_ray.source = ang₂.end_ray.source := sorry
 
-def sum_adj {ang₁ ang₂: Angle P} (h :ang₁.end_ray = ang₂.start_ray) : Angle P := Angle.mk ang₁.start_ray ang₂.end_ray (source_eq_source_of_adj h)
+def sum_adj {ang₁ ang₂: Angle P} (h : ang₁.end_ray = ang₂.start_ray) : Angle P :=
+  Angle.mk_two_ray_of_eq_source ang₁.start_ray ang₂.end_ray (source_eq_source_of_adj h)
 
 theorem ang_eq_ang_add_ang_mod_pi_of_adj_ang (ang₁ ang₂ : Angle P) (h: ang₁.end_ray = ang₂.start_ray) : (sum_adj h).value = ang₁.value + ang₂.value := sorry
 

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle_trash.lean
@@ -4,9 +4,11 @@ import EuclideanGeometry.Foundation.Axiom.Linear.Ray_trash
 
 namespace EuclidGeom
 
+open AngValue
+
 variable {P : Type _} [EuclideanPlane P]
 
-theorem sin_pos_iff_angle_pos (A : Angle P) : 0 < AngValue.sin A.value ↔ A.value.IsPos := sorry
+theorem Angle.sin_pos_iff_isPos (ang : Angle P) : 0 < sin ang.value ↔ ang.IsPos := isPos_iff_zero_lt_sin.symm
 
 theorem end_ray_toDir_rev_toDir_of_ang_rev_ang {ang₁ ang₂ : Angle P} (hs : ang₁.start_ray.toDir = (ang₂.start_ray).reverse.toDir) (h : ang₁.value = ang₂.value) : ang₁.end_ray.toDir = (ang₂.end_ray).reverse.toDir := sorry
 
@@ -30,30 +32,30 @@ theorem neg_dvalue_of_rev_ang {A B O: P} (h₁ : A ≠ O) (h₂ : B ≠ O) : (AN
 -- WangJingTing
 namespace Angle
 
-theorem end_ray_eq_value_vadd_start_ray (ang : Angle P) : ang.end_ray.toDir = ang.value +ᵥ ang.start_ray.toDir := sorry
+theorem end_ray_eq_value_vadd_start_ray (ang : Angle P) : ang.dir₂ = ang.value +ᵥ ang.dir₁ := sorry
 -- to replace
 /-
-theorem end_ray_eq_start_ray_mul_value {ang : Angle P} : ang.end_ray.toDir = ang.start_ray.toDir * ang.value.toDir := sorry
+theorem end_ray_eq_start_ray_mul_value {ang : Angle P} : ang.dir₂ = ang.dir₁ * ang.value.toDir := sorry
 -/
 
 theorem ang_source_eq_end_ray_source {ang : Angle P} : ang.source = ang.end_ray.source := sorry
 
 def mk_start_ray (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk_two_ray_of_eq_source ang.start_ray ray h
 
-def mk_ray_end (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk_two_ray_of_eq_source ray ang.end_ray (by rw[h.symm, ang_source_eq_end_ray_source])
+def mk_end_ray (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk_two_ray_of_eq_source ray ang.end_ray (by rw[h.symm, ang_source_eq_end_ray_source])
 
 theorem value_eq_vsub (ray₁ : Ray P) (ray₂ : Ray P) (h: ray₁.source = ray₂.source) : (Angle.mk_two_ray_of_eq_source ray₁ ray₂ h).value = ray₂.toDir -ᵥ ray₁.toDir := sorry
 
-theorem mk_strat_ray_value_eq_vsub (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : (Angle.mk_start_ray ang ray h).value = ray.toDir -ᵥ ang.start_ray.toDir := sorry
+theorem mk_strat_ray_value_eq_vsub (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : (Angle.mk_start_ray ang ray h).value = ray.toDir -ᵥ ang.dir₁ := sorry
 
-theorem mk_ray_end_value_eq_vsub (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : (Angle.mk_ray_end ang ray h).value = ang.end_ray.toDir -ᵥ ray.toDir := sorry
+theorem mk_end_ray_value_eq_vsub (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : (Angle.mk_end_ray ang ray h).value = ang.dir₂ -ᵥ ray.toDir := sorry
 -- to replace
 /-
 theorem value_eq_angdiff {ray₁ : Ray P} {ray₂ : Ray P} (h: ray₁.source = ray₂.source) : (Angle.mk_two_ray_of_eq_source ray₁ ray₂ h).value = Dir.AngDiff ray₁.toDir ray₂.toDir := sorry
 
-theorem mk_start_ray_value_eq_angdiff {ang : Angle P} {ray : Ray P} (h : ang.source = ray.source) : (Angle.mk_start_ray ang ray h).value = Dir.AngDiff ang.start_ray.toDir ray.toDir := sorry
+theorem mk_start_ray_value_eq_angdiff {ang : Angle P} {ray : Ray P} (h : ang.source = ray.source) : (Angle.mk_start_ray ang ray h).value = Dir.AngDiff ang.dir₁ ray.toDir := sorry
 
-theorem mk_ray_end_value_eq_angdiff {ang : Angle P} {ray : Ray P} (h : ang.source = ray.source) : (Angle.mk_ray_end ang ray h).value = Dir.AngDiff ray.toDir ang.end_ray.toDir := sorry
+theorem mk_end_ray_value_eq_angdiff {ang : Angle P} {ray : Ray P} (h : ang.source = ray.source) : (Angle.mk_end_ray ang ray h).value = Dir.AngDiff ray.toDir ang.dir₂ := sorry
 -/
 
 end Angle

--- a/EuclideanGeometry/Foundation/Axiom/Position/Angle_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Angle_trash.lean
@@ -38,34 +38,23 @@ theorem end_ray_eq_start_ray_mul_value {ang : Angle P} : ang.end_ray.toDir = ang
 
 theorem ang_source_eq_end_ray_source {ang : Angle P} : ang.source = ang.end_ray.source := sorry
 
-def mk_start_ray (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk ang.start_ray ray h
+def mk_start_ray (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk_two_ray_of_eq_source ang.start_ray ray h
 
-def mk_ray_end (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk ray ang.end_ray (by rw[h.symm, ang_source_eq_end_ray_source])
+def mk_ray_end (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : Angle P := Angle.mk_two_ray_of_eq_source ray ang.end_ray (by rw[h.symm, ang_source_eq_end_ray_source])
 
-theorem value_eq_vsub (ray₁ : Ray P) (ray₂ : Ray P) (h: ray₁.source = ray₂.source) : (Angle.mk ray₁ ray₂ h).value = ray₂.toDir -ᵥ ray₁.toDir := sorry
+theorem value_eq_vsub (ray₁ : Ray P) (ray₂ : Ray P) (h: ray₁.source = ray₂.source) : (Angle.mk_two_ray_of_eq_source ray₁ ray₂ h).value = ray₂.toDir -ᵥ ray₁.toDir := sorry
 
 theorem mk_strat_ray_value_eq_vsub (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : (Angle.mk_start_ray ang ray h).value = ray.toDir -ᵥ ang.start_ray.toDir := sorry
 
 theorem mk_ray_end_value_eq_vsub (ang : Angle P) (ray : Ray P) (h : ang.source = ray.source) : (Angle.mk_ray_end ang ray h).value = ang.end_ray.toDir -ᵥ ray.toDir := sorry
 -- to replace
 /-
-theorem value_eq_angdiff {ray₁ : Ray P} {ray₂ : Ray P} (h: ray₁.source = ray₂.source) : (Angle.mk ray₁ ray₂ h).value = Dir.AngDiff ray₁.toDir ray₂.toDir := sorry
+theorem value_eq_angdiff {ray₁ : Ray P} {ray₂ : Ray P} (h: ray₁.source = ray₂.source) : (Angle.mk_two_ray_of_eq_source ray₁ ray₂ h).value = Dir.AngDiff ray₁.toDir ray₂.toDir := sorry
 
 theorem mk_start_ray_value_eq_angdiff {ang : Angle P} {ray : Ray P} (h : ang.source = ray.source) : (Angle.mk_start_ray ang ray h).value = Dir.AngDiff ang.start_ray.toDir ray.toDir := sorry
 
 theorem mk_ray_end_value_eq_angdiff {ang : Angle P} {ray : Ray P} (h : ang.source = ray.source) : (Angle.mk_ray_end ang ray h).value = Dir.AngDiff ray.toDir ang.end_ray.toDir := sorry
 -/
-
-def reverse (ang: Angle P) : Angle P := Angle.mk ang.end_ray ang.start_ray ang.source_eq_source.symm
-
-theorem ang_source_rev_eq_source {ang : Angle P} : ang.reverse.source = ang.source := by
-  rw [ang.reverse.ang_source_eq_end_ray_source]
-  rw [ang.ang_source_eq_end_ray_source]
-  exact ang.source_eq_source
-
-theorem ang_value_rev_eq_neg_value {ang : Angle P} :  ang.reverse.value = - ang.value := by
-  unfold value reverse
-  simp
 
 end Angle
 

--- a/EuclideanGeometry/Foundation/Axiom/Position/Orientation.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Orientation.lean
@@ -7,7 +7,7 @@ import EuclideanGeometry.Foundation.Axiom.Position.Angle_trash
 noncomputable section
 namespace EuclidGeom
 
-open Classical AngValue
+open Classical AngValue Angle
 
 variable {P : Type*} [EuclideanPlane P]
 
@@ -80,11 +80,11 @@ theorem wedge_pos_iff_angle_pos (A B C : P) (nd : ¬colinear A B C) : (0 < wedge
     have h3 : 0 < sin (Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm).value := by
       field_simp at h0
       exact h0
-    rw [sin_pos_iff_angle_pos] at h3
+    rw [sin_pos_iff_isPos] at h3
     exact h3
   rw [wedge_eq_length_mul_length_mul_sin (bnea := ⟨(ne_of_not_colinear nd).2.2⟩) (cnea := ⟨(ne_of_not_colinear nd).2.1.symm⟩)]
   intro h0
-  have h3 : 0 < sin ((Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm).value) := (sin_pos_iff_angle_pos (Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm)).mpr h0
+  have h3 : 0 < sin ((Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm).value) := (sin_pos_iff_isPos (Angle.mk_pt_pt_pt B A C (ne_of_not_colinear nd).2.2 (ne_of_not_colinear nd).2.1.symm)).mpr h0
   field_simp
   exact h3
 

--- a/EuclideanGeometry/Foundation/Axiom/Position/Orientation.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Position/Orientation.lean
@@ -329,7 +329,7 @@ end handside
 section ray_toRay
 
 /- Statement of his theorem should change, since ray₀.source ≠ ray₂.source. -/
-theorem intersect_of_ray_on_left_iff (ray₁ ray₂ : Ray P) (h : ray₂.source ≠ ray₁.source) : let ray₀ := Ray.mk_pt_pt ray₁.source ray₂.source h; (0 < (Angle.mk ray₀ ray₁ rfl).value.toReal) ∧ ((Angle.mk ray₀ ray₁ rfl).value.toReal < (Angle.mk ray₀ ray₂ sorry).value.toReal) ∧ ((Angle.mk ray₀ ray₂ sorry).value.toReal < π) ↔ (∃ A : P, (A LiesOn ray₁) ∧ (A LiesOn ray₂) ∧ (A LiesOnLeft ray₀))  := sorry
+theorem intersect_of_ray_on_left_iff (ray₁ ray₂ : Ray P) (h : ray₂.source ≠ ray₁.source) : let ray₀ := Ray.mk_pt_pt ray₁.source ray₂.source h; (0 < (Angle.mk_two_ray_of_eq_source ray₀ ray₁ rfl).value.toReal) ∧ ((Angle.mk_two_ray_of_eq_source ray₀ ray₁ rfl).value.toReal < (Angle.mk_two_ray_of_eq_source ray₀ ray₂ sorry).value.toReal) ∧ ((Angle.mk_two_ray_of_eq_source ray₀ ray₂ sorry).value.toReal < π) ↔ (∃ A : P, (A LiesOn ray₁) ∧ (A LiesOn ray₂) ∧ (A LiesOnLeft ray₀))  := sorry
 
 end ray_toRay
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Basic_trash.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Basic_trash.lean
@@ -6,11 +6,10 @@ open AngValue
 
 variable {P : Type _} [EuclideanPlane P]
 
--- `IsAcute should be be prepared in Angle!!`
 structure TriangleND.IsAcute (tr_nd : TriangleND P) : Prop where
-  angle₁ : tr_nd.angle₁.value.IsAcu
-  angle₂ : tr_nd.angle₂.value.IsAcu
-  angle₃ : tr_nd.angle₃.value.IsAcu
+  angle₁ : tr_nd.angle₁.IsAcu
+  angle₂ : tr_nd.angle₂.IsAcu
+  angle₃ : tr_nd.angle₃.IsAcu
 
 variable {tr_nd₁ tr_nd₂ : TriangleND P}
 

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
@@ -369,7 +369,7 @@ theorem perm_congr (h : tr_nd₁.IsCongr tr_nd₂) : (perm_vertices tr_nd₁).Is
 theorem congr_iff_perm_congr (tr_nd₁ tr_nd₂ : TriangleND P) : tr_nd₁ ≅ tr_nd₂ ↔ perm_vertices tr_nd₁ ≅ perm_vertices tr_nd₂ :=
   ⟨fun h ↦ h.perm_congr, fun h ↦ h.perm_congr.perm_congr⟩
 
-theorem third_point_same_of_two_point_same (h : tr_nd₁.IsCongr tr_nd₂) (p₁ : tr_nd₁.point₁ = tr_nd₂.point₁) (p₂ : tr_nd₁.point₂ = tr_nd₂.point₂) : tr_nd₁.point₃ = tr_nd₂.point₃ := by
+theorem unique_of_eq_eq (h : tr_nd₁.IsCongr tr_nd₂) (p₁ : tr_nd₁.point₁ = tr_nd₂.point₁) (p₂ : tr_nd₁.point₂ = tr_nd₂.point₂) : tr_nd₁.point₃ = tr_nd₂.point₃ := by
   have ray_eq₁ : tr_nd₁.angle₁.end_ray = tr_nd₂.angle₁.end_ray := by
     apply eq_end_ray_of_eq_value_eq_start_ray
     unfold Angle.start_ray TriangleND.angle₁

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
@@ -380,14 +380,14 @@ theorem unique_of_eq_eq (h : tr_nd₁.IsCongr tr_nd₂) (p₁ : tr_nd₁.point�
     unfold Angle.end_ray TriangleND.angle₂
     simp only [<-p₂, <-p₁] ; rfl
     exact h.5
-  have l₁ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₁.end_ray.toLine :=
-    .inl Ray.snd_pt_lies_on_mk_pt_pt
-  have l₂ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₂.start_ray.toLine :=
-    .inl Ray.snd_pt_lies_on_mk_pt_pt
-  have l₃ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₁.end_ray.toLine :=
-    .inl Ray.snd_pt_lies_on_mk_pt_pt
-  have l₄ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₂.start_ray.toLine :=
-    .inl Ray.snd_pt_lies_on_mk_pt_pt
+  haveI : PtNe tr_nd₁.point₃ tr_nd₁.angle₁.source := (nontriv₂ tr_nd₁).symm
+  haveI : PtNe tr_nd₁.point₃ tr_nd₁.angle₂.source := nontriv₁ tr_nd₁
+  haveI : PtNe tr_nd₂.point₃ tr_nd₂.angle₁.source := (nontriv₂ tr_nd₂).symm
+  haveI : PtNe tr_nd₂.point₃ tr_nd₂.angle₂.source := nontriv₁ tr_nd₂
+  have l₁ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₁.end_ray.toLine := .inl Ray.snd_pt_lies_on_mk_pt_pt
+  have l₂ : tr_nd₁.point₃ LiesOn tr_nd₁.angle₂.start_ray.toLine := .inl Ray.snd_pt_lies_on_mk_pt_pt
+  have l₃ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₁.end_ray.toLine := .inl Ray.snd_pt_lies_on_mk_pt_pt
+  have l₄ : tr_nd₂.point₃ LiesOn tr_nd₂.angle₂.start_ray.toLine := .inl Ray.snd_pt_lies_on_mk_pt_pt
   have np₁ : ¬ tr_nd₁.angle₁.end_ray.toLine ∥ tr_nd₁.angle₂.start_ray.toLine := by
     by_contra pl
     have l₅ : tr_nd₁.point₁ LiesOn tr_nd₁.angle₁.end_ray.toLine := by

--- a/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
+++ b/EuclideanGeometry/Foundation/Axiom/Triangle/Congruence.lean
@@ -371,7 +371,7 @@ theorem congr_iff_perm_congr (tr_nd₁ tr_nd₂ : TriangleND P) : tr_nd₁ ≅ t
 
 theorem unique_of_eq_eq (h : tr_nd₁.IsCongr tr_nd₂) (p₁ : tr_nd₁.point₁ = tr_nd₂.point₁) (p₂ : tr_nd₁.point₂ = tr_nd₂.point₂) : tr_nd₁.point₃ = tr_nd₂.point₃ := by
   have ray_eq₁ : tr_nd₁.angle₁.end_ray = tr_nd₂.angle₁.end_ray := by
-    apply eq_end_ray_of_eq_value_eq_start_ray
+    apply end_ray_eq_of_value_eq_of_start_ray_eq
     unfold Angle.start_ray TriangleND.angle₁
     simp only [p₂, p₁] ; rfl
     exact h.4

--- a/EuclideanGeometry/Foundation/Construction/Triangle/AngleBisector.lean
+++ b/EuclideanGeometry/Foundation/Construction/Triangle/AngleBisector.lean
@@ -27,7 +27,7 @@ variable {P : Type _} [EuclideanPlane P]
 structure IsAngBis (ang : Angle P) (ray : Ray P) : Prop where
   eq_source : ang.source = ray.source
   eq_value : (Angle.mk_start_ray ang ray eq_source).value = (Angle.mk_ray_end ang ray eq_source).value
-  -- `the definition of same_sgn can be rewrite, using btw`
+  -- `the definition of same_sgn should be rewrite, using btw`, i.e., `btw ang.dir₁ ray.toDir ang.dir₂`
   same_sgn : ((Angle.mk_start_ray ang ray eq_source).value.IsPos ∧ ang.value.IsPos) ∨ ((Angle.mk_start_ray ang ray eq_source).value.IsNeg ∧ ang.value.IsNeg) ∨ ((Angle.mk_start_ray ang ray eq_source).value = ↑(π/2) ∧ ang.value = π ) ∨ ((Angle.mk_start_ray ang ray eq_source).value = 0 ∧ ang.value = 0)
 
 
@@ -72,7 +72,7 @@ theorem angbis_is_angbis {ang : Angle P} : IsAngBis ang ang.AngBis where
     rw [mk_strat_ray_value_eq_vsub]
     rw [mk_ray_end_value_eq_vsub]
     simp only [AngBis, vadd_vsub]
-    rw [vsub_vadd_eq_vsub_sub, ← value]
+    rw [vsub_vadd_eq_vsub_sub]
     exact sub_half_eq_half.symm
   same_sgn := by
     have g : (ang.value.IsPos) ∨ (ang.value.IsNeg) ∨ (ang.value = π) ∨ (ang.value = 0) := by
@@ -107,20 +107,18 @@ theorem angbis_iff_angbis {ang : Angle P} {r : Ray P} : IsAngBis ang r ↔ r = a
   · exact fun h ↦ (by rw [h]; apply angbis_is_angbis)
 
 
-theorem ang_source_rev_eq_source_bis {ang : Angle P} {r : Ray P} (h : IsAngBis ang r) : ang.reverse.source = r.source := by rw[ang.ang_source_rev_eq_source, h.eq_source]
+theorem ang_source_rev_eq_source_bis {ang : Angle P} {r : Ray P} (h : IsAngBis ang r) : ang.reverse.source = r.source := h.eq_source
 
 theorem nonpi_bisector_eq_bisector_of_rev {ang : Angle P} {r : Ray P} (h : IsAngBis ang r) (nonpi : ang.value ≠ π ): IsAngBis ang.reverse r where
-  eq_source := by rw[h.eq_source.symm, ang.ang_source_rev_eq_source]
+  eq_source := h.eq_source
   eq_value := by
+    unfold mk_start_ray mk_ray_end mk_two_ray_of_eq_source reverse start_ray end_ray value
+    rw [← neg_vsub_eq_vsub_rev ang.dir₂ r.toDir, ← neg_vsub_eq_vsub_rev r.toDir ang.dir₁]
+    exact neg_inj.mpr h.eq_value.symm
+  same_sgn := sorry /- by
     have : (Angle.mk_start_ray ang.reverse r (ang_source_rev_eq_source_bis h)) = (Angle.mk_ray_end ang r h.eq_source).reverse := rfl
-    rw [this, (Angle.mk_ray_end ang r h.eq_source).ang_value_rev_eq_neg_value]
-    have : (Angle.mk_ray_end ang.reverse r (ang_source_rev_eq_source_bis h)) = (Angle.mk_start_ray ang r h.eq_source).reverse := rfl
-    rw [this, (Angle.mk_start_ray ang r h.eq_source).ang_value_rev_eq_neg_value]
-    simp [h.eq_value]
-  same_sgn := by
-    have : (Angle.mk_start_ray ang.reverse r (ang_source_rev_eq_source_bis h)) = (Angle.mk_ray_end ang r h.eq_source).reverse := rfl
-    rw [this, (Angle.mk_ray_end ang r h.eq_source).ang_value_rev_eq_neg_value]
-    rw [ang.ang_value_rev_eq_neg_value]
+    rw [this, (Angle.mk_ray_end ang r h.eq_source).rev_value_eq_neg_value]
+    rw [ang.rev_value_eq_neg_value]
     simp
     rw [h.eq_value.symm]
     rcases h.same_sgn with h₁ | h₂ | h₃ | h₄
@@ -128,7 +126,7 @@ theorem nonpi_bisector_eq_bisector_of_rev {ang : Angle P} {r : Ray P} (h : IsAng
     · exact Or.inl h₂
     · absurd nonpi
       exact h₃.2
-    · exact Or.inr (Or.inr (Or.inr h₄))
+    · exact Or.inr (Or.inr (Or.inr h₄)) -/
 
 
 theorem bisector_eq_bisector_of_rev' {ang : Angle P} : ang.AngBis = ang.reverse.AngBis := by

--- a/EuclideanGeometry/Foundation/Construction/Triangle/AngleBisector.lean
+++ b/EuclideanGeometry/Foundation/Construction/Triangle/AngleBisector.lean
@@ -12,7 +12,7 @@ import EuclideanGeometry.Foundation.Axiom.Basic.Angle_trash
 noncomputable section
 namespace EuclidGeom
 
-open AngValue
+open AngValue Angle
 
 variable {P : Type _} [EuclideanPlane P]
 
@@ -26,8 +26,9 @@ variable {P : Type _} [EuclideanPlane P]
 
 structure IsAngBis (ang : Angle P) (ray : Ray P) : Prop where
   eq_source : ang.source = ray.source
-  eq_value : (Angle.mk_start_ray ang ray eq_source).value = (Angle.mk_ray_end ang ray eq_source).value
-  -- `the definition of same_sgn should be rewrite, using btw`, i.e., `btw ang.dir₁ ray.toDir ang.dir₂`
+  eq_value : (mk_dir₁ ang ray.toDir).value = (mk_dir₂ ang ray.toDir).value
+  -- `the definition of same_sgn should be rewrite, using btw`.
+  -- For example, change it to `sbtw ang.dir₁ ray.toDir ang.dir₂ ∨ (ray.toDir =ang.dir₁ ∧ ray.toDir = ang.dir₂)`.
   same_sgn : ((Angle.mk_start_ray ang ray eq_source).value.IsPos ∧ ang.value.IsPos) ∨ ((Angle.mk_start_ray ang ray eq_source).value.IsNeg ∧ ang.value.IsNeg) ∨ ((Angle.mk_start_ray ang ray eq_source).value = ↑(π/2) ∧ ang.value = π ) ∨ ((Angle.mk_start_ray ang ray eq_source).value = 0 ∧ ang.value = 0)
 
 
@@ -44,13 +45,13 @@ namespace Angle
 /- when the Angle is flat, bis is on the left side-/
 def AngBis (ang : Angle P) : Ray P where
   source := ang.source
-  toDir := ang.value.half +ᵥ ang.start_ray.toDir
+  toDir := ang.value.half +ᵥ ang.dir₁
 
 def AngBisLine (ang : Angle P) : Line P := ang.AngBis.toLine
 
 def ExAngBis (ang : Angle P) : Ray P where
   source := ang.source
-  toDir := ∠[ang.value.toReal/2 + π/2] +ᵥ ang.start_ray.toDir
+  toDir := ∠[ang.value.toReal/2 + π/2] +ᵥ ang.dir₁
 
 def ExAngBisLine (ang : Angle P) : Line P := ang.ExAngBis.toLine
 
@@ -63,16 +64,13 @@ theorem eq_source {ang : Angle P} : ang.source = ang.AngBis.source := rfl
 theorem value_angBis_eq_half_value {ang : Angle P} : (Angle.mk_start_ray ang ang.AngBis rfl).value = ang.value.half := by
   simp only [mk_strat_ray_value_eq_vsub, AngBis, vadd_vsub]
 
-theorem  mk_start_ray_value_eq_half_angvalue {ang : Angle P} : (Angle.mk_start_ray ang ang.AngBis rfl).value.toReal = ang.value.toReal / 2 :=
+theorem mk_start_ray_value_eq_half_angvalue {ang : Angle P} : (Angle.mk_start_ray ang ang.AngBis rfl).value.toReal = ang.value.toReal / 2 :=
   (Eq.congr_right (ang.value.half_toReal).symm).mpr (congrArg toReal ang.value_angBis_eq_half_value)
 
 theorem angbis_is_angbis {ang : Angle P} : IsAngBis ang ang.AngBis where
   eq_source := rfl
   eq_value := by
-    rw [mk_strat_ray_value_eq_vsub]
-    rw [mk_ray_end_value_eq_vsub]
-    simp only [AngBis, vadd_vsub]
-    rw [vsub_vadd_eq_vsub_sub]
+    simp only [value_mk_dir₁, value_mk_dir₂, AngBis, vadd_vsub, vsub_vadd_eq_vsub_sub]
     exact sub_half_eq_half.symm
   same_sgn := by
     have g : (ang.value.IsPos) ∨ (ang.value.IsNeg) ∨ (ang.value = π) ∨ (ang.value = 0) := by
@@ -91,14 +89,14 @@ theorem angbis_is_angbis {ang : Angle P} : IsAngBis ang ang.AngBis where
       left
       constructor
       · apply toReal_eq_pi_div_two_iff.mp
-        simp only [ mk_start_ray_value_eq_half_angvalue, g₃, neg_lt_self_iff, toReal_pi]
+        simp only [mk_start_ray_value_eq_half_angvalue, g₃, neg_lt_self_iff, toReal_pi]
       · exact g₃
     · right
       right
       right
       constructor
       · rw [← AngValue.toReal_inj]
-        simp only [ mk_start_ray_value_eq_half_angvalue, g₄, toReal_zero, zero_div]
+        simp only [mk_start_ray_value_eq_half_angvalue, g₄, toReal_zero, zero_div]
       · exact g₄
 
 theorem angbis_iff_angbis {ang : Angle P} {r : Ray P} : IsAngBis ang r ↔ r = ang.AngBis := by
@@ -112,12 +110,12 @@ theorem ang_source_rev_eq_source_bis {ang : Angle P} {r : Ray P} (h : IsAngBis a
 theorem nonpi_bisector_eq_bisector_of_rev {ang : Angle P} {r : Ray P} (h : IsAngBis ang r) (nonpi : ang.value ≠ π ): IsAngBis ang.reverse r where
   eq_source := h.eq_source
   eq_value := by
-    unfold mk_start_ray mk_ray_end mk_two_ray_of_eq_source reverse start_ray end_ray value
+    simp only [value_mk_dir₁, value_mk_dir₂, reverse]
     rw [← neg_vsub_eq_vsub_rev ang.dir₂ r.toDir, ← neg_vsub_eq_vsub_rev r.toDir ang.dir₁]
     exact neg_inj.mpr h.eq_value.symm
   same_sgn := sorry /- by
-    have : (Angle.mk_start_ray ang.reverse r (ang_source_rev_eq_source_bis h)) = (Angle.mk_ray_end ang r h.eq_source).reverse := rfl
-    rw [this, (Angle.mk_ray_end ang r h.eq_source).rev_value_eq_neg_value]
+    have : (Angle.mk_start_ray ang.reverse r (ang_source_rev_eq_source_bis h)) = (Angle.mk_end_ray ang r h.eq_source).reverse := rfl
+    rw [this, (Angle.mk_end_ray ang r h.eq_source).rev_value_eq_neg_value]
     rw [ang.rev_value_eq_neg_value]
     simp
     rw [h.eq_value.symm]
@@ -170,7 +168,7 @@ namespace TriangleND
 theorem angbisline_of_angle₁_angle₂_not_parallel {tri_nd : TriangleND P} : ¬ tri_nd.angle₁.AngBis.toLine ∥ tri_nd.angle₂.AngBis.toLine := by
   by_contra g
   let A₁ := (Angle.mk_start_ray tri_nd.angle₁ tri_nd.angle₁.AngBis tri_nd.angle₁.eq_source).reverse
-  let A₂ := Angle.mk_ray_end tri_nd.angle₂ tri_nd.angle₂.AngBis tri_nd.angle₂.eq_source
+  let A₂ := Angle.mk_end_ray tri_nd.angle₂ tri_nd.angle₂.AngBis tri_nd.angle₂.eq_source
   have sr : A₁.start_ray.toDir = A₂.start_ray.toDir := by
     have h₁ : A₁.start_ray = tri_nd.angle₁.AngBis := rfl
     have h₂ : A₂.start_ray = tri_nd.angle₂.AngBis := rfl


### PR DESCRIPTION
@jjdishere
Main Changes:
AddToMathlib.lean : 

- Finish the part of the compatibility among group, `AddTorsor` and order

Vector.lean : 

- Realize `Dir` as a circular ordered `AddTorsor`

Line.lean : 
1. Realize a directed line as a linearly ordered `AddTorsor`
2. Add induction principles to deduce results for directed lines or lines from those for rays
3. Add some theorems about `DirLine.ddist` and fix some theorems

Position/Angle.lean :

- Changed the definition of `Angle`. Now an angle is determined by a vertex and two directions.